### PR TITLE
AAP-841 Setter saksnummer hvis sak finnes for oppgave

### DIFF
--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/avklaringsbehov/flate/AvklaringsbehovAPI.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/avklaringsbehov/flate/AvklaringsbehovAPI.kt
@@ -5,6 +5,7 @@ import com.papsign.ktor.openapigen.route.response.respondWithStatus
 import com.papsign.ktor.openapigen.route.route
 import io.ktor.http.*
 import no.nav.aap.komponenter.dbconnect.transaction
+import no.nav.aap.komponenter.gateway.GatewayProvider
 import no.nav.aap.komponenter.httpklient.auth.bruker
 import no.nav.aap.lookup.repository.RepositoryProvider
 import no.nav.aap.motor.FlytJobbRepository
@@ -15,6 +16,7 @@ import no.nav.aap.postmottak.avklaringsbehov.BehandlingTilstandValidator
 import no.nav.aap.postmottak.avklaringsbehov.LøsAvklaringsbehovBehandlingHendelse
 import no.nav.aap.postmottak.faktagrunnlag.journalpostIdFraBehandlingResolver
 import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.JournalpostRepository
+import no.nav.aap.postmottak.gateway.BehandlingsflytGateway
 import no.nav.aap.postmottak.hendelse.avløp.BehandlingHendelseServiceImpl
 import no.nav.aap.postmottak.journalpostogbehandling.behandling.BehandlingRepository
 import no.nav.aap.postmottak.journalpostogbehandling.behandling.flate.BehandlingReferanseService
@@ -62,7 +64,8 @@ fun NormalOpenAPIRoute.avklaringsbehovApi(dataSource: DataSource) {
                                 connection,
                                 BehandlingHendelseServiceImpl(
                                     flytJobbRepository,
-                                    journalpostRepository
+                                    journalpostRepository,
+                                    GatewayProvider.provide(BehandlingsflytGateway::class),
                                 )
                             ),
                         ).håndtere(

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/hendelse/mottak/BehandlingHendelseHåndterer.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/hendelse/mottak/BehandlingHendelseHåndterer.kt
@@ -1,10 +1,12 @@
 package no.nav.aap.postmottak.hendelse.mottak
 
 import no.nav.aap.komponenter.dbconnect.DBConnection
+import no.nav.aap.komponenter.gateway.GatewayProvider
 import no.nav.aap.lookup.repository.RepositoryProvider
 import no.nav.aap.motor.FlytJobbRepository
 import no.nav.aap.postmottak.avklaringsbehov.AvklaringsbehovOrkestrator
 import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.JournalpostRepository
+import no.nav.aap.postmottak.gateway.BehandlingsflytGateway
 import no.nav.aap.postmottak.hendelse.avløp.BehandlingHendelseServiceImpl
 import no.nav.aap.postmottak.journalpostogbehandling.behandling.BehandlingId
 
@@ -14,7 +16,8 @@ class BehandlingHendelseHåndterer(connection: DBConnection) {
         connection,
         BehandlingHendelseServiceImpl(
             FlytJobbRepository(connection),
-            RepositoryProvider(connection).provide(JournalpostRepository::class)
+            RepositoryProvider(connection).provide(JournalpostRepository::class),
+            GatewayProvider.provide(BehandlingsflytGateway::class),
         )
     )
 

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/prosessering/ProsesserBehandlingJobbUtfører.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/prosessering/ProsesserBehandlingJobbUtfører.kt
@@ -2,6 +2,7 @@ package no.nav.aap.postmottak.prosessering
 
 import no.nav.aap.behandlingsflyt.flyt.steg.internal.StegKonstruktørImpl
 import no.nav.aap.komponenter.dbconnect.DBConnection
+import no.nav.aap.komponenter.gateway.GatewayProvider
 import no.nav.aap.lookup.repository.RepositoryProvider
 import no.nav.aap.motor.FlytJobbRepository
 import no.nav.aap.motor.Jobb
@@ -11,6 +12,7 @@ import no.nav.aap.postmottak.avklaringsbehov.AvklaringsbehovRepository
 import no.nav.aap.postmottak.faktagrunnlag.InformasjonskravGrunnlagImpl
 import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.JournalpostRepository
 import no.nav.aap.postmottak.flyt.FlytOrkestrator
+import no.nav.aap.postmottak.gateway.BehandlingsflytGateway
 import no.nav.aap.postmottak.hendelse.avløp.BehandlingHendelseServiceImpl
 import no.nav.aap.postmottak.journalpostogbehandling.behandling.BehandlingFlytRepository
 import no.nav.aap.postmottak.journalpostogbehandling.behandling.BehandlingId
@@ -53,7 +55,8 @@ class ProsesserBehandlingJobbUtfører(
                     ),
                     BehandlingHendelseServiceImpl(
                         FlytJobbRepository(connection),
-                        journalpostRepository
+                        journalpostRepository,
+                        GatewayProvider.provide(BehandlingsflytGateway::class),
                     ),
                 )
             )

--- a/flyt/src/test/kotlin/no/nav/aap/postmottak/avklaringsbehov/AvklaringsbehovOrkestratorTest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/postmottak/avklaringsbehov/AvklaringsbehovOrkestratorTest.kt
@@ -1,14 +1,18 @@
 package no.nav.aap.postmottak.avklaringsbehov
 
+import io.mockk.every
 import io.mockk.mockk
 import no.nav.aap.komponenter.dbconnect.DBConnection
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.dbtest.InitTestDatabase
+import no.nav.aap.komponenter.gateway.GatewayProvider
+import no.nav.aap.komponenter.gateway.GatewayRegistry
 import no.nav.aap.komponenter.httpklient.auth.Bruker
 import no.nav.aap.lookup.repository.RepositoryProvider
 import no.nav.aap.lookup.repository.RepositoryRegistry
 import no.nav.aap.motor.FlytJobbRepository
 import no.nav.aap.postmottak.avklaringsbehov.løser.ÅrsakTilSettPåVent
+import no.nav.aap.postmottak.gateway.BehandlingsflytGateway
 import no.nav.aap.postmottak.hendelse.avløp.BehandlingHendelseServiceImpl
 import no.nav.aap.postmottak.hendelse.mottak.BehandlingSattPåVent
 import no.nav.aap.postmottak.journalpostogbehandling.behandling.BehandlingRepository
@@ -47,7 +51,8 @@ class AvklaringsbehovOrkestratorTest {
             val behandlingHendelseService =
                 BehandlingHendelseServiceImpl(
                     FlytJobbRepository(connection),
-                    mockk(relaxed = true)
+                    mockk(relaxed = true),
+                    mockk(relaxed = true),
                 )
 
             val avklaringsbehovOrkestrator = AvklaringsbehovOrkestrator(

--- a/kontrakt/src/main/kotlin/no/nav/aap/postmottak/kontrakt/hendelse/DokumentflytStoppetHendelse.kt
+++ b/kontrakt/src/main/kotlin/no/nav/aap/postmottak/kontrakt/hendelse/DokumentflytStoppetHendelse.kt
@@ -15,6 +15,5 @@ data class DokumentflytStoppetHendelse(
     val avklaringsbehov: List<AvklaringsbehovHendelseDto>,
     val opprettetTidspunkt: LocalDateTime,
     val hendelsesTidspunkt: LocalDateTime,
-    @Deprecated("Denne er alltid null. Vil bli fjernet.")
     val saksnummer: String? = null
 )


### PR DESCRIPTION
Legger til saksnummer for oppgaver dersom det finnes en eksisterende sak som kan kobles til oppgaven.

Merk: 
- Dette er "best effort" ved å hente ut saken med den nyeste rettighetsperioden - det er ikke en garanti for at dette alltid vil være riktig dersom bruker har flere saker. Pr nå er ikke dette et problem, men mulig dette må sees på når brukere etterhvert potensielt får flere oppgaver et stykke frem i tid.