### PR TITLE
legger til servicebruker for innsikt og målinger

### DIFF
--- a/lib-test/src/main/resources/flyway/V0.0__dbtest.sql
+++ b/lib-test/src/main/resources/flyway/V0.0__dbtest.sql
@@ -1,3 +1,6 @@
 -- V0.0__dbtest.sql brukes til å opprette ting som finnes på GCP.
 DROP ROLE IF EXISTS cloudsqliamuser;
 CREATE ROLE cloudsqliamuser;
+
+DROP ROLE IF EXISTS cloudsqliamserviceaccount;
+CREATE ROLE cloudsqliamserviceaccount;

--- a/repository/src/main/resources/flyway/V1.50__legger_til_servicebruker_innsikt.sql
+++ b/repository/src/main/resources/flyway/V1.50__legger_til_servicebruker_innsikt.sql
@@ -1,0 +1,7 @@
+GRANT
+SELECT
+    ON ALL TABLES IN SCHEMA public to cloudsqliamserviceaccount;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT
+SELECT
+    ON TABLES TO cloudsqliamserviceaccount;


### PR DESCRIPTION
Legger til en servicebruker for innsikt og målinger i Seksjon for AAP

Denne servicebrukeren vil kjøre uttrekk mot app-databasen inntil vi har opprettet en dedikert database til formålet. Da kan den fjernes. 