### PR TITLE
AAP-1158 Ny regel for oppgitte barn uten fnr

### DIFF
--- a/flyt/src/main/kotlin/no/nav/aap/fordeler/regler/AlleOppgitteBarnHarIdentRegel.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/fordeler/regler/AlleOppgitteBarnHarIdentRegel.kt
@@ -1,0 +1,78 @@
+package no.nav.aap.fordeler.regler
+
+import no.nav.aap.behandlingsflyt.kontrakt.hendelse.dokumenter.OppgitteBarn
+import no.nav.aap.behandlingsflyt.kontrakt.hendelse.dokumenter.SøknadV0
+import no.nav.aap.komponenter.dbconnect.DBConnection
+import no.nav.aap.komponenter.gateway.GatewayProvider
+import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.JournalpostService
+import no.nav.aap.postmottak.gateway.DokumentGateway
+import no.nav.aap.postmottak.gateway.DokumentTilMeldingParser
+import no.nav.aap.postmottak.journalpostogbehandling.journalpost.BrevkoderHelper
+import no.nav.aap.postmottak.kontrakt.journalpost.JournalpostId
+
+/**
+ * Frem til Kelvin har støtte for å håndtere oppgitte barn som mangler ident,
+ * må søknader som mangler dette rutes til Arena hvor det kan håndteres manuelt.
+ **/
+class AlleOppgitteBarnHarIdentRegel : Regel<OppgitteBarnRegelInput> {
+    companion object : RegelFactory<OppgitteBarnRegelInput> {
+        // TODO:
+        //  Skru av dev når det er testet OK
+        override val erAktiv = miljøConfig(prod = true, dev = true)
+
+        override fun medDataInnhenting(connection: DBConnection?): RegelMedInputgenerator<OppgitteBarnRegelInput> {
+            requireNotNull(connection)
+
+            val journalpostService = JournalpostService.konstruer(connection)
+            val dokumentGateway = GatewayProvider.provide(DokumentGateway::class)
+
+            return RegelMedInputgenerator(
+                AlleOppgitteBarnHarIdentRegel(),
+                AlleOppgitteBarnHarIdentRegelInputGenerator(journalpostService, dokumentGateway)
+            )
+        }
+
+    }
+
+    override fun regelNavn(): String = this::class.simpleName!!
+
+    override fun vurder(input: OppgitteBarnRegelInput): Boolean {
+        return input.oppgitteBarn?.barn?.none { it.ident == null } ?: true
+    }
+
+}
+
+class AlleOppgitteBarnHarIdentRegelInputGenerator(
+    private val journalpostService: JournalpostService,
+    private val dokumentGateway: DokumentGateway,
+) : InputGenerator<OppgitteBarnRegelInput> {
+
+    override fun generer(input: RegelInput): OppgitteBarnRegelInput {
+        val journalpost = journalpostService
+            .hentJournalpost(JournalpostId(input.journalpostId))
+
+        return if (journalpost.erDigitalSøknad()) {
+            val strukturertDokument = requireNotNull(journalpost.finnOriginal()) {
+                "Journalpost er digital søknad, men mangler strukturert dokument"
+            }
+
+            val dokumentBytes = dokumentGateway
+                .hentDokument(journalpost.journalpostId, strukturertDokument.dokumentInfoId)
+                .dokument
+                .readBytes()
+
+            val innsending = BrevkoderHelper.mapTilInnsendingType(journalpost.hoveddokumentbrevkode)
+
+            val søknad = DokumentTilMeldingParser.parseTilMelding(dokumentBytes, innsending) as SøknadV0
+
+            OppgitteBarnRegelInput(søknad.oppgitteBarn)
+        } else {
+            OppgitteBarnRegelInput(null)
+        }
+    }
+
+}
+
+data class OppgitteBarnRegelInput(
+    val oppgitteBarn: OppgitteBarn?,
+)

--- a/flyt/src/main/kotlin/no/nav/aap/fordeler/regler/AlleOppgitteBarnHarIdentRegel.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/fordeler/regler/AlleOppgitteBarnHarIdentRegel.kt
@@ -37,7 +37,9 @@ class AlleOppgitteBarnHarIdentRegel : Regel<OppgitteBarnRegelInput> {
     override fun regelNavn(): String = this::class.simpleName!!
 
     override fun vurder(input: OppgitteBarnRegelInput): Boolean {
-        return input.oppgitteBarn?.barn?.none { it.ident == null } ?: true
+        val oppgitteBarn = input.oppgitteBarn?.barn.orEmpty()
+
+        return oppgitteBarn.none { it.ident == null }
     }
 
 }

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/forretningsflyt/steg/dokumentflyt/DigitaliserDokumentSteg.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/forretningsflyt/steg/dokumentflyt/DigitaliserDokumentSteg.kt
@@ -1,6 +1,5 @@
 package no.nav.aap.postmottak.forretningsflyt.steg.dokumentflyt
 
-import no.nav.aap.behandlingsflyt.kontrakt.hendelse.InnsendingType
 import no.nav.aap.komponenter.dbconnect.DBConnection
 import no.nav.aap.komponenter.gateway.GatewayProvider
 import no.nav.aap.lookup.repository.RepositoryProvider
@@ -18,7 +17,7 @@ import no.nav.aap.postmottak.gateway.DokumentGateway
 import no.nav.aap.postmottak.gateway.DokumentTilMeldingParser
 import no.nav.aap.postmottak.gateway.serialiser
 import no.nav.aap.postmottak.journalpostogbehandling.flyt.FlytKontekstMedPerioder
-import no.nav.aap.postmottak.journalpostogbehandling.journalpost.Brevkoder
+import no.nav.aap.postmottak.journalpostogbehandling.journalpost.BrevkoderHelper
 import no.nav.aap.postmottak.journalpostogbehandling.journalpost.Journalpost
 import no.nav.aap.postmottak.kontrakt.avklaringsbehov.Definisjon
 import no.nav.aap.postmottak.kontrakt.steg.StegType
@@ -60,7 +59,7 @@ class DigitaliserDokumentSteg(
                 if (journalpost.erDigitalSøknad() || journalpost.erDigitaltMeldekort()) hentOriginalDokumentFraSaf(
                     journalpost
                 ) else null
-            val innsending = getInnsendingForBrevkode(journalpost.hoveddokumentbrevkode)
+            val innsending = BrevkoderHelper.mapTilInnsendingType(journalpost.hoveddokumentbrevkode)
             val validertDokument =
                 DokumentTilMeldingParser.parseTilMelding(dokument, innsending)?.serialiser()
             digitaliseringsvurderingRepository.lagre(
@@ -82,18 +81,5 @@ class DigitaliserDokumentSteg(
             journalpost.journalpostId,
             strukturertDokument.dokumentInfoId
         ).dokument.readBytes()
-    }
-
-    private fun getInnsendingForBrevkode(brevkode: String): InnsendingType {
-        val brevkodeTilInnsendingMap = mapOf(
-            Brevkoder.SØKNAD to InnsendingType.SØKNAD,
-            Brevkoder.LEGEERKLÆRING to InnsendingType.LEGEERKLÆRING,
-            Brevkoder.MELDEKORT to InnsendingType.MELDEKORT,
-            Brevkoder.MELDEKORT_KORRIGERING to InnsendingType.MELDEKORT,
-            Brevkoder.KLAGE to InnsendingType.KLAGE
-        )
-
-        return brevkodeTilInnsendingMap[Brevkoder.fraKode(brevkode)]
-            ?: throw IllegalStateException("Kan ikke automatisk behanlde journalposter av type $brevkode")
     }
 }

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/journalpostogbehandling/journalpost/Brevkoder.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/journalpostogbehandling/journalpost/Brevkoder.kt
@@ -1,5 +1,7 @@
 package no.nav.aap.postmottak.journalpostogbehandling.journalpost
 
+import no.nav.aap.behandlingsflyt.kontrakt.hendelse.InnsendingType
+
 /**
  * NB: Behandlingstypene er hentet fra felles kodeverk - og må oppdateres dersom kodeverket endres.
  * Behandlingstypene er hentet fra TemaSkjemaRuting.
@@ -35,4 +37,20 @@ enum class Behandlingstype(val kode: String) {
     KLAGE("ae0058"),
     EU_EØS_PRAKSISENDRING("ae0237"),
     UTLAND("ae0106");
+}
+
+object BrevkoderHelper {
+    fun mapTilInnsendingType(brevkode: String): InnsendingType {
+        val brevkodeTilInnsendingMap = mapOf(
+            Brevkoder.SØKNAD to InnsendingType.SØKNAD,
+            Brevkoder.LEGEERKLÆRING to InnsendingType.LEGEERKLÆRING,
+            Brevkoder.MELDEKORT to InnsendingType.MELDEKORT,
+            Brevkoder.MELDEKORT_KORRIGERING to InnsendingType.MELDEKORT,
+            Brevkoder.KLAGE to InnsendingType.KLAGE
+        )
+
+        return brevkodeTilInnsendingMap[Brevkoder.fraKode(brevkode)]
+            ?: throw IllegalStateException("Uhåndtert kode '$brevkode' – kan ikke mappe til InnsendingType")
+    }
+
 }

--- a/flyt/src/test/kotlin/no/nav/aap/fordeler/regler/AldersregelTest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/fordeler/regler/AldersregelTest.kt
@@ -17,7 +17,7 @@ class AldersregelTest {
     fun `Journalpost for person yngre enn 60 år skal til Kelvin`(){
         val fødselsdato = LocalDate.of(1960,2, 15)
         val nåDato = LocalDate.of(2020, 2, 14)
-        assert(Aldersregel().vurder(AldersregelInput(fødselsdato, nåDato)))
+        assertTrue(Aldersregel().vurder(AldersregelInput(fødselsdato, nåDato)))
     }
 
     @Test

--- a/flyt/src/test/kotlin/no/nav/aap/fordeler/regler/AlleOppgitteBarnHarIdentRegelTest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/fordeler/regler/AlleOppgitteBarnHarIdentRegelTest.kt
@@ -1,0 +1,204 @@
+package no.nav.aap.fordeler.regler
+
+import io.mockk.Called
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import no.nav.aap.behandlingsflyt.kontrakt.hendelse.dokumenter.Ident
+import no.nav.aap.behandlingsflyt.kontrakt.hendelse.dokumenter.ManueltOppgittBarn
+import no.nav.aap.behandlingsflyt.kontrakt.hendelse.dokumenter.OppgitteBarn
+import no.nav.aap.behandlingsflyt.kontrakt.hendelse.dokumenter.SøknadV0
+import no.nav.aap.komponenter.json.DefaultJsonMapper
+import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.JournalpostService
+import no.nav.aap.postmottak.gateway.DokumentGateway
+import no.nav.aap.postmottak.gateway.Journalstatus
+import no.nav.aap.postmottak.gateway.SafDocumentResponse
+import no.nav.aap.postmottak.journalpostogbehandling.behandling.dokumenter.KanalFraKodeverk
+import no.nav.aap.postmottak.journalpostogbehandling.journalpost.Brevkoder
+import no.nav.aap.postmottak.journalpostogbehandling.journalpost.Dokument
+import no.nav.aap.postmottak.journalpostogbehandling.journalpost.DokumentInfoId
+import no.nav.aap.postmottak.journalpostogbehandling.journalpost.Filtype
+import no.nav.aap.postmottak.journalpostogbehandling.journalpost.Journalpost
+import no.nav.aap.postmottak.journalpostogbehandling.journalpost.Person
+import no.nav.aap.postmottak.journalpostogbehandling.journalpost.Variant
+import no.nav.aap.postmottak.journalpostogbehandling.journalpost.Variantformat
+import no.nav.aap.postmottak.kontrakt.journalpost.JournalpostId
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+import kotlin.random.Random.Default.nextLong
+
+internal class AlleOppgitteBarnHarIdentRegelTest {
+
+    private val regel = spyk(AlleOppgitteBarnHarIdentRegel())
+
+    private val journalpostService = mockk<JournalpostService>()
+    private val dokumentGateway = mockk<DokumentGateway>()
+
+    private val generator = AlleOppgitteBarnHarIdentRegelInputGenerator(journalpostService, dokumentGateway)
+
+    @AfterEach
+    fun afterEach() {
+        clearAllMocks()
+    }
+
+    @ParameterizedTest
+    @EnumSource(Brevkoder::class, names = ["SØKNAD"], mode = EnumSource.Mode.EXCLUDE)
+    fun `Alt som ikke er digital søknad skal ignoreres`(brevkode: Brevkoder) {
+        val journalpostId = JournalpostId(nextLong())
+        val dokumentId = DokumentInfoId("1")
+        val journalpost = opprettJournalpost(
+            journalpostId,
+            Dokument(dokumentId, brevkode.kode, listOf(Variant(Filtype.JSON, Variantformat.ORIGINAL)))
+        )
+
+        every { journalpostService.hentJournalpost(journalpostId) } returns journalpost
+
+        val input = generator.generer(RegelInput(journalpostId.referanse, mockk(), ""))
+
+        val resultat = regel.vurder(input)
+
+        assertTrue(resultat)
+
+        verify {
+            regel.vurder(OppgitteBarnRegelInput(null))
+            journalpostService.hentJournalpost(journalpostId)
+            dokumentGateway wasNot Called
+        }
+    }
+
+    @Test
+    fun `Ingen barn oppgitt`() {
+        val journalpostId = JournalpostId(nextLong())
+        val dokumentId = DokumentInfoId("1")
+
+        every { journalpostService.hentJournalpost(journalpostId) } returns opprettJournalpost(
+            journalpostId,
+            Dokument(dokumentId, Brevkoder.SØKNAD.kode, listOf(Variant(Filtype.JSON, Variantformat.ORIGINAL)))
+        )
+        every { dokumentGateway.hentDokument(journalpostId, dokumentId) } returns opprettSafResponse(null)
+
+        val input = generator.generer(RegelInput(journalpostId.referanse, mockk(), ""))
+
+        val resultat = regel.vurder(input)
+
+        assertTrue(resultat)
+
+        verify {
+            journalpostService.hentJournalpost(journalpostId)
+            dokumentGateway.hentDokument(journalpostId, dokumentId)
+            regel.vurder(OppgitteBarnRegelInput(null))
+        }
+    }
+
+    @Test
+    fun `Alle oppgitte barn har ident`() {
+        val journalpostId = JournalpostId(nextLong())
+        val dokumentId = DokumentInfoId("1")
+        val oppgitteBarn = OppgitteBarn(
+            emptySet(), listOf(
+                ManueltOppgittBarn(ident = Ident("33221101234")),
+                ManueltOppgittBarn(navn = "navn", ident = Ident("33221101234")),
+                ManueltOppgittBarn(ident = Ident("33221101234"), fødselsdato = LocalDate.now()),
+            )
+        )
+
+        every { journalpostService.hentJournalpost(journalpostId) } returns opprettJournalpost(
+            journalpostId,
+            Dokument(dokumentId, Brevkoder.SØKNAD.kode, listOf(Variant(Filtype.JSON, Variantformat.ORIGINAL)))
+        )
+        every { dokumentGateway.hentDokument(journalpostId, dokumentId) } returns opprettSafResponse(oppgitteBarn)
+
+        val input = generator.generer(RegelInput(journalpostId.referanse, mockk(), ""))
+
+        val resultat = regel.vurder(input)
+
+        assertTrue(resultat)
+
+        verify {
+            journalpostService.hentJournalpost(journalpostId)
+            dokumentGateway.hentDokument(journalpostId, dokumentId)
+            regel.vurder(OppgitteBarnRegelInput(oppgitteBarn))
+        }
+    }
+
+    @Test
+    fun `Finnes barn uten ident`() {
+        val journalpostId = JournalpostId(nextLong())
+        val dokumentId = DokumentInfoId("1")
+
+        val oppgitteBarn = OppgitteBarn(
+            emptySet(), listOf(
+                ManueltOppgittBarn(ident = Ident("33221101234")),
+                ManueltOppgittBarn(navn = "navn", ident = Ident("33221101234")),
+                ManueltOppgittBarn(fødselsdato = LocalDate.now()), // Mangler ident
+            )
+        )
+
+        every { journalpostService.hentJournalpost(journalpostId) } returns opprettJournalpost(
+            journalpostId,
+            Dokument(dokumentId, Brevkoder.SØKNAD.kode, listOf(Variant(Filtype.JSON, Variantformat.ORIGINAL)))
+        )
+        every { dokumentGateway.hentDokument(journalpostId, dokumentId) } returns opprettSafResponse(oppgitteBarn)
+
+        val input = generator.generer(RegelInput(journalpostId.referanse, mockk(), ""))
+        val resultat = regel.vurder(input)
+
+        assertFalse(resultat)
+
+        verify {
+            journalpostService.hentJournalpost(journalpostId)
+            dokumentGateway.hentDokument(journalpostId, dokumentId)
+            regel.vurder(OppgitteBarnRegelInput(oppgitteBarn))
+        }
+    }
+
+    private fun opprettJournalpost(
+        journalpostId: JournalpostId,
+        dokument: Dokument? = null
+    ) =
+        Journalpost(
+            journalpostId = journalpostId,
+            person = Person(nextLong(), UUID.randomUUID(), emptyList()),
+            journalførendeEnhet = null,
+            tema = "AAP",
+            behandlingstema = null,
+            status = Journalstatus.JOURNALFOERT,
+            mottattDato = LocalDate.now(),
+            mottattTid = LocalDateTime.now(),
+            dokumenter = listOfNotNull(
+                dokument,
+                Dokument(
+                    dokumentInfoId = DokumentInfoId("2"),
+                    brevkode = Brevkoder.ANNEN.kode,
+                    varianter = listOf(Variant(Filtype.PDF, Variantformat.ARKIV))
+                ),
+            ),
+            kanal = KanalFraKodeverk.NAV_NO,
+            saksnummer = null,
+            fagsystem = null
+        )
+
+    private fun opprettSafResponse(oppgitteBarn: OppgitteBarn? = null): SafDocumentResponse {
+        val melding = SøknadV0(
+            student = null,
+            yrkesskade = "",
+            oppgitteBarn = oppgitteBarn,
+            medlemskap = null
+        )
+
+        return SafDocumentResponse(
+            DefaultJsonMapper.toJson(melding).toByteArray().inputStream(),
+            "contentType",
+            "filnavn"
+        )
+    }
+}

--- a/flyt/src/test/kotlin/no/nav/aap/postmottak/forretningsflyt/steg/dokumentflyt/DigitaliserDokumentStegTest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/postmottak/forretningsflyt/steg/dokumentflyt/DigitaliserDokumentStegTest.kt
@@ -68,7 +68,7 @@ class DigitaliserDokumentStegTest {
         val journalpostJson = """{
             |"yrkesskade": "Nei",
             |"student": {"erStudent": "Nei", "kommeTilbake": "Nei"},
-            |"oppgitteBarn": {"identer": []}
+            |"oppgitteBarn": {"identer": [], "barn": []}
             |}""".trimMargin()
 
         every { journalpost.erDigitalSøknad() } returns true
@@ -86,7 +86,6 @@ class DigitaliserDokumentStegTest {
         val stegresultat = digitaliserDokumentSteg.utfør(mockk(relaxed = true))
 
         assertEquals(Fullført::class.simpleName, stegresultat::class.simpleName)
-
     }
 
     @Test


### PR DESCRIPTION
Ny regel som henter ut strukturert dokument (hvis digital søknad) og sjekker om det er oppgitt barn som mangler ident. 
Hvis ja, skal regelen sikre at det rutes til Arena i stedet for Kelvin. 