### PR TITLE
Aap 1280 filtrer gradert uføreregel

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -30,6 +30,9 @@ outbound:
     - application: statistikk
     - application: skjermede-personer-pip
       namespace: nom
+    - application: pensjon-pen-q2
+      namespace: pensjon-q2
+      cluster: dev-fss
   external:
     - host: saf.dev-fss-pub.nais.io
     - host: dokarkiv.dev-fss-pub.nais.io
@@ -37,6 +40,7 @@ outbound:
     - host: pdl-api.dev-fss-pub.nais.io
     - host: aap-fss-proxy.dev-fss-pub.nais.io
     - host: veilarbarena.dev-fss-pub.nais.io
+    - host: pensjon-pen-q2.dev-fss-pub.nais.io
 
 env:
   - name: INTEGRASJON_SAF_URL_GRAPHQL
@@ -97,3 +101,7 @@ env:
     value: https://veilarbarena.dev-fss-pub.nais.io
   - name: INTEGRASJON_VEILARBARENA_SCOPE
     value: api://dev-fss.pto.veilarbarena/.default
+  - name: INTEGRASJON_PESYS_URL
+    value: https://pensjon-pen-q2.dev-fss-pub.nais.io
+  - name: INTEGRASJON_PESYS_SCOPE
+    value: api://dev-fss.pensjon-q2.pensjon-pen-q2/.default

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -25,6 +25,9 @@ outbound:
     - application: statistikk
     - application: oppgave
     - application: behandlingsflyt
+    - application: pensjon-pen
+      namespace: pensjondeployer
+      cluster: prod-fss
   external:
     - host: saf.prod-fss-pub.nais.io
     - host: dokarkiv.prod-fss-pub.nais.io
@@ -32,6 +35,7 @@ outbound:
     - host: pdl-api.prod-fss-pub.nais.io
     - host: aap-fss-proxy.prod-fss-pub.nais.io
     - host: veilarbarena.prod-fss-pub.nais.io
+    - host: pensjon-pen.prod-fss-pub.nais.io
 
 env:
   - name: INTEGRASJON_SAF_URL_GRAPHQL
@@ -92,3 +96,7 @@ env:
     value: http://statistikk
   - name: INTEGRASJON_STATISTIKK_SCOPE
     value: api://prod-gcp.aap.statistikk/.default
+  - name: INTEGRASJON_PESYS_URL
+    value: https://pensjon-pen.prod-fss-pub.nais.io
+  - name: INTEGRASJON_PESYS_SCOPE
+    value: api://prod-fss.pensjondeployer.pensjon-pen/.default

--- a/flyt/src/main/kotlin/no/nav/aap/fordeler/regler/ErIkkeGradertUføreRegel.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/fordeler/regler/ErIkkeGradertUføreRegel.kt
@@ -1,0 +1,57 @@
+package no.nav.aap.fordeler.regler
+
+import no.nav.aap.komponenter.gateway.GatewayProvider
+import no.nav.aap.lookup.repository.RepositoryProvider
+import no.nav.aap.postmottak.gateway.Uføre
+import no.nav.aap.postmottak.gateway.UføreRegisterGateway
+import org.slf4j.LoggerFactory
+import java.time.LocalDate
+
+/**
+ *  Det er bestilt endring i Arena sin måte å håndtere denne samordningen på slik at det gjøres likt som i Kelvin,
+ *  men det tar tid før denne er på plass. I mellomtiden ønsker vi å unngå at slike saker kommer inn i Kelvin.
+ **/
+class ErIkkeGradertUføreRegel : Regel<GradertUføreRegelInput> {
+    companion object : RegelFactory<GradertUføreRegelInput> {
+        override val erAktiv = miljøConfig(prod = false, dev = false)
+        private val log = LoggerFactory.getLogger(javaClass)
+
+        override fun medDataInnhenting(
+            repositoryProvider: RepositoryProvider?,
+            gatewayProvider: GatewayProvider?
+        ): RegelMedInputgenerator<GradertUføreRegelInput> {
+            return RegelMedInputgenerator(
+                ErIkkeGradertUføreRegel(),
+                GradertUføreRegelInputGenerator(requireNotNull(gatewayProvider))
+            )
+        }
+
+    }
+
+    override fun vurder(input: GradertUføreRegelInput): Boolean {
+        if (input.uførePerioder.isEmpty()) {
+            return true
+        } else {
+            log.info("Fant periode i PESYS med gradert uføre, returnerer false")
+            return false
+        }
+    }
+
+    override fun regelNavn(): String = this::class.simpleName!!
+}
+
+class GradertUføreRegelInputGenerator(
+    private val gatewayProvider: GatewayProvider,
+) : InputGenerator<GradertUføreRegelInput> {
+    override fun generer(input: RegelInput): GradertUføreRegelInput {
+        val fnr = input.person.aktivIdent().identifikator
+        val klient = gatewayProvider.provide(UføreRegisterGateway::class)
+        val uførePerioder = klient.innhentPerioder(fnr, LocalDate.now())
+
+        return GradertUføreRegelInput(uførePerioder)
+    }
+}
+
+data class GradertUføreRegelInput(
+    val uførePerioder: List<Uføre>
+)

--- a/flyt/src/main/kotlin/no/nav/aap/fordeler/regler/ErIkkeGradertUføreRegel.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/fordeler/regler/ErIkkeGradertUføreRegel.kt
@@ -25,11 +25,11 @@ class ErIkkeGradertUføreRegel : Regel<GradertUføreRegelInput> {
                 GradertUføreRegelInputGenerator(requireNotNull(gatewayProvider))
             )
         }
-
     }
 
     override fun vurder(input: GradertUføreRegelInput): Boolean {
-        if (input.uførePerioder.isEmpty()) {
+        val relevantePerioder = input.uførePerioder.filter { it.uføregrad != null && it.uføregrad > 0 }
+        if (relevantePerioder.isEmpty()) {
             return true
         } else {
             log.info("Fant periode i PESYS med gradert uføre, returnerer false")

--- a/flyt/src/main/kotlin/no/nav/aap/fordeler/regler/ErIkkeGradertUføreRegel.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/fordeler/regler/ErIkkeGradertUføreRegel.kt
@@ -13,7 +13,7 @@ import java.time.LocalDate
  **/
 class ErIkkeGradertUføreRegel : Regel<GradertUføreRegelInput> {
     companion object : RegelFactory<GradertUføreRegelInput> {
-        override val erAktiv = miljøConfig(prod = false, dev = false)
+        override val erAktiv = miljøConfig(prod = false, dev = true)
         private val log = LoggerFactory.getLogger(javaClass)
 
         override fun medDataInnhenting(

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/gateway/UføreRegisterGateway.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/gateway/UføreRegisterGateway.kt
@@ -1,7 +1,6 @@
 package no.nav.aap.postmottak.gateway
 
 import no.nav.aap.komponenter.gateway.Gateway
-import no.nav.aap.komponenter.verdityper.Prosent
 import java.time.LocalDate
 
 interface UføreRegisterGateway : Gateway {
@@ -13,7 +12,7 @@ interface UføreRegisterGateway : Gateway {
 
 data class Uføre(
     val virkningstidspunkt: LocalDate,
-    val uføregrad: Prosent
+    val uføregrad: Int?
 )
 
 data class UføreRequest (

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/gateway/UføreRegisterGateway.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/gateway/UføreRegisterGateway.kt
@@ -1,0 +1,24 @@
+package no.nav.aap.postmottak.gateway
+
+import no.nav.aap.komponenter.gateway.Gateway
+import no.nav.aap.komponenter.verdityper.Prosent
+import java.time.LocalDate
+
+interface UføreRegisterGateway : Gateway {
+    fun innhentPerioder(
+        fnr: String,
+        fraDato: LocalDate
+    ): List<Uføre>
+}
+
+data class Uføre(
+    val virkningstidspunkt: LocalDate,
+    val uføregrad: Prosent
+)
+
+data class UføreRequest (
+    val fnr: String,
+    val dato: String,
+)
+
+data class UføreHistorikkRespons(val uforeperioder: List<UførePeriode>)

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/gateway/UføreRegisterKlient.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/gateway/UføreRegisterKlient.kt
@@ -1,0 +1,84 @@
+package no.nav.aap.postmottak.gateway
+
+import no.nav.aap.postmottak.PrometheusProvider
+
+import no.nav.aap.komponenter.config.requiredConfigForKey
+import no.nav.aap.komponenter.gateway.Factory
+import no.nav.aap.komponenter.httpklient.httpclient.ClientConfig
+import no.nav.aap.komponenter.httpklient.httpclient.Header
+import no.nav.aap.komponenter.httpklient.httpclient.RestClient
+import no.nav.aap.komponenter.httpklient.httpclient.error.IkkeFunnetException
+import no.nav.aap.komponenter.httpklient.httpclient.post
+import no.nav.aap.komponenter.httpklient.httpclient.request.PostRequest
+import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.azurecc.ClientCredentialsTokenProvider
+import no.nav.aap.komponenter.verdityper.Prosent
+import org.slf4j.LoggerFactory
+import java.net.URI
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+/**
+ * @param uforegrad Uføregrad i prosent. `null` om personen er registrert i systemet, men ikke har uføregrad.
+ */
+
+data class UførePeriode(
+    val uforegradFom: LocalDate? = null,
+    val uforegradTom: LocalDate? = null,
+    val uforegrad: Int,
+    val uforetidspunkt: LocalDate? = null,
+    val virkningstidspunkt: LocalDate
+)
+
+class UføreRegisterKlient() : UføreRegisterGateway {
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val url = URI.create(requiredConfigForKey("integrasjon.pesys.url"))
+    private val config = ClientConfig(scope = requiredConfigForKey("integrasjon.pesys.scope"))
+
+    private val client = RestClient.withDefaultResponseHandler(
+        config = config,
+        tokenProvider = ClientCredentialsTokenProvider,
+        prometheus = PrometheusProvider.prometheus
+    )
+
+    companion object : Factory<UføreRegisterKlient> {
+        override fun konstruer(): UføreRegisterKlient {
+            return UføreRegisterKlient()
+        }
+    }
+
+    private fun queryMedHistorikk(uføreRequest: UføreRequest): UføreHistorikkRespons? {
+        val httpRequest = PostRequest(
+            additionalHeaders = listOf(
+                Header("fnr", uføreRequest.fnr),
+                Header("Nav-Consumer-Id", "aap-behandlingsflyt"),
+                Header("Accept", "application/json")
+            ),
+            body = uføreRequest
+        )
+
+        val uri = url.resolve("pen/api/uforetrygd/uforehistorikk/perioder")
+        try {
+            return client.post(
+                uri = uri,
+                request = httpRequest
+            )
+        } catch (e: IkkeFunnetException) {
+            log.info("Fant ikke person i PESYS. Returnerer null. Message: ${e.message}")
+            return null
+        }
+    }
+
+    override fun innhentPerioder(fnr: String, fraDato: LocalDate): List<Uføre> {
+        val datoString = fraDato.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+        val request = UføreRequest(fnr, datoString)
+        val uføreResponse = queryMedHistorikk(request)
+        val uføreperioder = uføreResponse?.uforeperioder ?: emptyList()
+
+        return uføreperioder.map {
+            Uføre(
+                virkningstidspunkt = it.virkningstidspunkt,
+                uføregrad = Prosent(it.uforegrad)
+            )
+        }
+    }
+}

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/gateway/UføreRegisterKlient.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/gateway/UføreRegisterKlient.kt
@@ -24,7 +24,7 @@ import java.time.format.DateTimeFormatter
 data class UførePeriode(
     val uforegradFom: LocalDate? = null,
     val uforegradTom: LocalDate? = null,
-    val uforegrad: Int,
+    val uforegrad: Int?,
     val uforetidspunkt: LocalDate? = null,
     val virkningstidspunkt: LocalDate
 )
@@ -77,7 +77,7 @@ class UføreRegisterKlient() : UføreRegisterGateway {
         return uføreperioder.map {
             Uføre(
                 virkningstidspunkt = it.virkningstidspunkt,
-                uføregrad = Prosent(it.uforegrad)
+                uføregrad = it.uforegrad
             )
         }
     }

--- a/flyt/src/test/kotlin/no/nav/aap/WithDependencies.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/WithDependencies.kt
@@ -3,6 +3,7 @@ package no.nav.aap
 import io.mockk.mockk
 import no.nav.aap.komponenter.gateway.GatewayRegistry
 import no.nav.aap.postmottak.PrometheusProvider
+import no.nav.aap.postmottak.gateway.UføreRegisterKlient
 import no.nav.aap.postmottak.klient.AapInternApiKlient
 import no.nav.aap.postmottak.klient.arena.ArenaKlient
 import no.nav.aap.postmottak.klient.arena.VeilarbarenaKlient
@@ -39,6 +40,7 @@ interface WithDependencies {
                 .register<AapInternApiKlient>()
                 .register<FakeStatistikkKlient>()
                 .register<VeilarbarenaKlient>()
+                .register<UføreRegisterKlient>()
 
             PrometheusProvider.prometheus = mockk(relaxed = true)
         }

--- a/flyt/src/test/kotlin/no/nav/aap/fordeler/regler/ErIkkeGradertUføreRegelTest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/fordeler/regler/ErIkkeGradertUføreRegelTest.kt
@@ -1,0 +1,20 @@
+package no.nav.aap.fordeler.regler
+
+import no.nav.aap.postmottak.gateway.Uføre
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ErIkkeGradertUføreRegelTest {
+    @Test
+    fun `Person med gradert uføre skal ikke til Kelvin`() {
+        val perioder = listOf<Uføre>()
+        assertFalse(ErIkkeGradertUføreRegel().vurder(GradertUføreRegelInput(perioder)))
+    }
+
+    @Test
+    fun `Person uten gradert uføre skal til Kelvin`() {
+        val perioder = listOf<Uføre>()
+        assertTrue(ErIkkeGradertUføreRegel().vurder(GradertUføreRegelInput(perioder)))
+    }
+}

--- a/flyt/src/test/kotlin/no/nav/aap/fordeler/regler/ErIkkeGradertUføreRegelTest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/fordeler/regler/ErIkkeGradertUføreRegelTest.kt
@@ -4,17 +4,23 @@ import no.nav.aap.postmottak.gateway.Uføre
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 
 class ErIkkeGradertUføreRegelTest {
     @Test
     fun `Person med gradert uføre skal ikke til Kelvin`() {
-        val perioder = listOf<Uføre>()
+        val perioder = listOf(
+            Uføre(LocalDate.now(), 1)
+        )
         assertFalse(ErIkkeGradertUføreRegel().vurder(GradertUføreRegelInput(perioder)))
     }
 
     @Test
     fun `Person uten gradert uføre skal til Kelvin`() {
-        val perioder = listOf<Uføre>()
+        val perioder = listOf(
+            Uføre(LocalDate.now(), null),
+            Uføre(LocalDate.now(), 0),
+        )
         assertTrue(ErIkkeGradertUføreRegel().vurder(GradertUføreRegelInput(perioder)))
     }
 }

--- a/klienter/src/main/kotlin/no/nav/aap/postmottak/klient/DefaultGatewayProvider.kt
+++ b/klienter/src/main/kotlin/no/nav/aap/postmottak/klient/DefaultGatewayProvider.kt
@@ -3,6 +3,7 @@ package no.nav.aap.postmottak.klient
 import no.nav.aap.komponenter.gateway.GatewayProvider
 import no.nav.aap.komponenter.gateway.GatewayRegistry
 import no.nav.aap.postmottak.gateway.DoksikkerhetsnettGateway
+import no.nav.aap.postmottak.gateway.UføreRegisterKlient
 import no.nav.aap.postmottak.klient.arena.ArenaKlient
 import no.nav.aap.postmottak.klient.arena.VeilarbarenaKlient
 import no.nav.aap.postmottak.klient.behandlingsflyt.BehandlingsflytKlient
@@ -39,5 +40,6 @@ fun defaultGatewayProvider(utvidelser: GatewayRegistry.() -> Unit = {}) = create
     register<VeilarbarenaKlient>()
     register<UnleashService>()
     register<DoksikkerhetsnettGatewayImpl>()
+    register<UføreRegisterKlient>()
     utvidelser()
 }

--- a/lib-test/src/main/kotlin/no/nav/aap/postmottak/test/FakeServers.kt
+++ b/lib-test/src/main/kotlin/no/nav/aap/postmottak/test/FakeServers.kt
@@ -386,7 +386,7 @@ object FakeServers : AutoCloseable {
         }
         install(StatusPages) {
             exception<Throwable> { call, cause ->
-                this@pesysFake.log.info("Inntekt :: Ukjent feil ved kall til '{}'", call.request.local.uri, cause)
+                this@pesysFake.log.info("PESYS :: Ukjent feil ved kall til '{}'", call.request.local.uri, cause)
                 call.respond(
                     status = HttpStatusCode.InternalServerError,
                     message = ErrorRespons(cause.message)

--- a/lib-test/src/main/kotlin/no/nav/aap/postmottak/test/modell/TestPerson.kt
+++ b/lib-test/src/main/kotlin/no/nav/aap/postmottak/test/modell/TestPerson.kt
@@ -16,6 +16,7 @@ class TestPerson(
     val identer: Set<Ident> = setOf(genererIdent(fødselsdato.toLocalDate())),
     val barn: List<TestPerson> = emptyList(),
     val navn: PersonNavn = FiktivtNavnGenerator.genererNavn(),
+    var uføre: Int? = null,
 ) {
     override fun toString(): String {
         return "TestPerson(fødselsdato=$fødselsdato, identer=$identer, barn=$barn, navn=$navn"


### PR DESCRIPTION
Nytt filter for å ikke route saker til Kelvin hvor vedkommende har gradert uføre. Grunn til dette er at det er forskjellig implementert i Arena og Kelvin, og det er til ugunst for bruker å havne i Kelvin per nå. Mens vi venter på at Arena fikser dette, må vi route alle slike tilfeller dit.