### PR TITLE
Håndter at geografiskTilknytning ikke finnes i PDL

### DIFF
--- a/flyt/src/main/kotlin/no/nav/aap/fordeler/Enhetsutreder.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/fordeler/Enhetsutreder.kt
@@ -73,7 +73,11 @@ class Enhetsutreder(
         val adressebeskyttelseOgGeoTilknytning = pdlKlient.hentAdressebeskyttelseOgGeolokasjon(person.aktivIdent())
 
         val geografiskTilknytning =
-            mapGeografiskTilknytningTilKode(adressebeskyttelseOgGeoTilknytning.geografiskTilknytning)
+            adressebeskyttelseOgGeoTilknytning.geografiskTilknytning?.let {
+                mapGeografiskTilknytningTilKode(
+                    adressebeskyttelseOgGeoTilknytning.geografiskTilknytning
+                )
+            }
         val diskresjonskode =
             adressebeskyttelseOgGeoTilknytning.adressebeskyttelse.firstOrNull()?.gradering?.tilDiskresjonskode()
                 ?: Diskresjonskode.ANY

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/gateway/PersondataGateway.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/gateway/PersondataGateway.kt
@@ -42,7 +42,7 @@ enum class GeografiskTilknytningType{
 }
 
 data class GeografiskTilknytningOgAdressebeskyttelse(
-    val geografiskTilknytning: GeografiskTilknytning,
+    val geografiskTilknytning: GeografiskTilknytning?,
     val adressebeskyttelse: List<Gradering>
 )
 

--- a/klienter/src/main/kotlin/no/nav/aap/postmottak/klient/pdl/PdlGraphqlKlient.kt
+++ b/klienter/src/main/kotlin/no/nav/aap/postmottak/klient/pdl/PdlGraphqlKlient.kt
@@ -97,7 +97,7 @@ class PdlGraphqlKlient : PersondataGateway {
 
         val data = response.data ?: error("Unexpected response from PDL: ${response.errors}")
         return GeografiskTilknytningOgAdressebeskyttelse(
-            geografiskTilknytning = data.hentGeografiskTilknytning ?: error("Geografisk tilknytning mangler"),
+            geografiskTilknytning = data.hentGeografiskTilknytning,
             adressebeskyttelse = data.hentPerson?.adressebeskyttelse.orEmpty()
         )
     }

--- a/klienter/src/test/kotlin/no/nav/aap/postmottak/klient/pdl/PdlTest.kt
+++ b/klienter/src/test/kotlin/no/nav/aap/postmottak/klient/pdl/PdlTest.kt
@@ -45,7 +45,7 @@ class PdlTest {
     fun `Kan parse geografiskTilknytning`() {
         val test = PdlGraphqlKlient().hentAdressebeskyttelseOgGeolokasjon(Ident("1234"))
         assertThat(test.adressebeskyttelse).isEqualTo(listOf(Gradering(Adressebeskyttelseskode.UGRADERT)))
-        assertThat(test.geografiskTilknytning.gtType).isEqualTo(GeografiskTilknytningType.KOMMUNE)
-        assertThat(test.geografiskTilknytning.gtKommune).isEqualTo("3207")
+        assertThat(test.geografiskTilknytning?.gtType).isEqualTo(GeografiskTilknytningType.KOMMUNE)
+        assertThat(test.geografiskTilknytning?.gtKommune).isEqualTo("3207")
     }
 }


### PR DESCRIPTION
Konsekvensen er at det opprettes fordelingsoppgave i Gosys