### PR TITLE
Update build.gradle.kts med nyeste teamdokumenthandtering-avro-schemas

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,7 +83,7 @@ dependencies {
     implementation("org.apache.avro:avro:1.12.0")
 
     implementation("io.confluent:kafka-streams-avro-serde:8.0.0")
-    implementation("no.nav.teamdokumenthandtering:teamdokumenthandtering-avro-schemas:08271806")
+    implementation("no.nav.teamdokumenthandtering:teamdokumenthandtering-avro-schemas:1.1.6")
 
     testImplementation(libs.kafkaStreamsTestUtils)
 

--- a/flyt/build.gradle.kts
+++ b/flyt/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation(libs.kafkaStreams)
     implementation("org.apache.avro:avro:1.12.0")
     implementation("io.confluent:kafka-streams-avro-serde:8.0.0")
-    implementation("no.nav.teamdokumenthandtering:teamdokumenthandtering-avro-schemas:08271806")
+    implementation("no.nav.teamdokumenthandtering:teamdokumenthandtering-avro-schemas:1.1.6")
 
     testImplementation("org.apache.kafka:kafka-streams-test-utils:$kafkaVersion")
     testImplementation(libs.bundles.junit)


### PR DESCRIPTION
Hei! Dere bruker en gammel versjon av teamdokumenthandtering-avro-schemas. Vi brukte tidligere git short hash til å identifisere versjon, men dette skaper krøll for Dependabot som ikke forstår hva som er nyeste versjon. Vi har gått over til semver og vil at dere oppdaterer slik at vi kan slette de gamle releasene og Dependabot foreslår riktig versjon for oppdateringer.
Kan dere sjekke at oppdatering til siste versjon av teamdokumenthandtering-avro-schemas går fint og ta det i bruk?