### PR TITLE
Koble sammen journalføring og dokumentbehandling

### DIFF
--- a/api/src/main/kotlin/no/nav/aap/postmottak/api/flyt/BehandlingFlytOgTilstandDto.kt
+++ b/api/src/main/kotlin/no/nav/aap/postmottak/api/flyt/BehandlingFlytOgTilstandDto.kt
@@ -3,6 +3,7 @@ package no.nav.aap.postmottak.api.flyt
 import no.nav.aap.postmottak.flyt.flate.visning.Visning
 import no.nav.aap.postmottak.kontrakt.steg.StegGruppe
 import no.nav.aap.postmottak.kontrakt.steg.StegType
+import java.util.UUID
 
 data class BehandlingFlytOgTilstandDto(
     val flyt: List<FlytGruppe>,
@@ -10,5 +11,6 @@ data class BehandlingFlytOgTilstandDto(
     val aktivGruppe: StegGruppe,
     val behandlingVersjon: Long,
     val prosessering: Prosessering,
-    val visning: Visning
+    val visning: Visning,
+    val nesteBehandlingId: UUID?
 )

--- a/api/src/main/kotlin/no/nav/aap/postmottak/api/flyt/FlytAPI.kt
+++ b/api/src/main/kotlin/no/nav/aap/postmottak/api/flyt/FlytAPI.kt
@@ -41,14 +41,21 @@ import no.nav.aap.tilgang.authorizedPost
 import org.slf4j.MDC
 import javax.sql.DataSource
 
-fun NormalOpenAPIRoute.flytApi(dataSource: DataSource, repositoryRegistry: RepositoryRegistry, gatewayProvider: GatewayProvider) {
+fun NormalOpenAPIRoute.flytApi(
+    dataSource: DataSource,
+    repositoryRegistry: RepositoryRegistry,
+    gatewayProvider: GatewayProvider
+) {
     route("/api/behandling") {
         route("/{referanse}/flyt") {
             authorizedGet<BehandlingsreferansePathParam, BehandlingFlytOgTilstandDto>(
                 AuthorizationParamPathConfig(
                     journalpostPathParam = JournalpostPathParam(
                         "referanse",
-                        journalpostIdFraBehandlingResolver(dataSource = dataSource, repositoryRegistry = repositoryRegistry)
+                        journalpostIdFraBehandlingResolver(
+                            dataSource = dataSource,
+                            repositoryRegistry = repositoryRegistry
+                        )
                     )
                 )
             ) { req ->
@@ -65,11 +72,12 @@ fun NormalOpenAPIRoute.flytApi(dataSource: DataSource, repositoryRegistry: Repos
 
 
                     // ved avsluttet journalføringsbehandling, finn id til dokumenthåndteringsbehandlingen som hører til samme journalpost
-                    val dokumentHåndteringBehnandlingId = if(behandling.typeBehandling == TypeBehandling.Journalføring && behandling.status() == Status.AVSLUTTET) {
-                        behandlingRepository.hentAlleBehandlingerForSak(behandling.journalpostId)
-                            .find { it.typeBehandling == TypeBehandling.DokumentHåndtering }
-                            ?.referanse?.referanse
-                    } else null
+                    val dokumentHåndteringBehnandlingId =
+                        if (behandling.typeBehandling == TypeBehandling.Journalføring && behandling.status() == Status.AVSLUTTET) {
+                            behandlingRepository.hentAlleBehandlingerForSak(behandling.journalpostId)
+                                .find { it.typeBehandling == TypeBehandling.DokumentHåndtering }
+                                ?.referanse?.referanse
+                        } else null
                     val prosessering =
                         Prosessering(
                             utledStatus(jobber),


### PR DESCRIPTION
Hvis nåværende behandling er av type journalføring og er avsluttet --> finn behandling på samme journalpostid av type dokumentbehandling, returner behandlingsid hvis finnes.

Skal brukes i frontend til å lenke videre til dokumentbehandlingen slik at saksbehandlier slipper å gå via oppgaveliste for å komme seg fra journalføring til dokumenthåndtering