### PR TITLE
Logg hvilken journalpostId fordelingen gjelder

### DIFF
--- a/flyt/src/main/kotlin/no/nav/aap/fordeler/FordelerRegelService.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/fordeler/FordelerRegelService.kt
@@ -25,6 +25,7 @@ data class Regelresultat(val regelMap: RegelMap, val forJournalpost: Long, val s
     fun skalTilKelvin(): Boolean {
         val manueltOverstyrtTilArena = regelMap[ManueltOverstyrtTilArenaRegel::class.simpleName] ?: false
         if (manueltOverstyrtTilArena) {
+            log.info("Sak med journalpostId=$forJournalpost går til Arena pga manuell overstyring")
             return false
         }
 
@@ -36,7 +37,7 @@ data class Regelresultat(val regelMap: RegelMap, val forJournalpost: Long, val s
             requireNotNull(regelMap[ErIkkeAnkeRegel::class.simpleName]) { "Mangler resultat fra ${ErIkkeAnkeRegel::class.simpleName}. JournalpostId: $forJournalpost" }
 
         if (sakFinnesIKelvin && erIkkeReisestønad && erIkkeAnke) {
-            log.info("Evaluering av KelvinSakRegel ga true: journalpost skal til Kelvin")
+            log.info("Evaluering av KelvinSakRegel ga true: journalpostId=$forJournalpost skal til Kelvin")
             return true
         }
         val reglerTilEvaluering =
@@ -44,7 +45,7 @@ data class Regelresultat(val regelMap: RegelMap, val forJournalpost: Long, val s
 
         return reglerTilEvaluering.values.all { it }.also {
             log.info(
-                "Skal til Kelvin: $it. ${
+                "journalpostId=$forJournalpost skal til Kelvin? $it ${
                     if (!it) "\n Følgende regler ga false: ${
                         reglerTilEvaluering.filter { !it.value }.map { it.key }
                     }" else ""

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/prosessering/FordelingVideresendJobbUtfører.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/prosessering/FordelingVideresendJobbUtfører.kt
@@ -67,12 +67,17 @@ class FordelingVideresendJobbUtfører(
             routeTilKelvin(journalpostId)
             prometheus.fordelingsCounter(Fagsystem.kelvin).increment()
         } else {
-            arenaVideresender.videresendJournalpostTilArena(
-                journalpostId,
-                innkommendeJournalpostId = innkommendeJournalpostId
-            )
+            routeTilArena(journalpostId, innkommendeJournalpostId)
             prometheus.fordelingsCounter(Fagsystem.arena).increment()
         }
+    }
+
+    private fun routeTilArena(journalpostId: JournalpostId, innkommendeJournalpostId: Long) {
+        log.info("Oppretter IKKE behandling for journalpost som skal til Arena: $journalpostId")
+        arenaVideresender.videresendJournalpostTilArena(
+            journalpostId,
+            innkommendeJournalpostId = innkommendeJournalpostId
+        )
     }
 
     private fun routeTilKelvin(journalpostId: JournalpostId) {


### PR DESCRIPTION
Under debugging av to porten-saker erfarte @Toxi2209 og jeg at det er vanskelig å se utfallet av en bestemt journalpost sin regel-evaluering for fordeling til Arena/Kelvin. 

Endringen legger til info-logger med informasjonen. 