### PR TITLE
Kjør ny Arenahistorikk-regel også i Prod, men bare passivt

### DIFF
--- a/flyt/src/main/kotlin/no/nav/aap/fordeler/regler/SignifikantArenaHistorikkRegel.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/fordeler/regler/SignifikantArenaHistorikkRegel.kt
@@ -13,7 +13,7 @@ class SignifikantArenaHistorikkRegel(
 ) : Regel<SignifikantArenaHistorikkRegelInput> {
 
     companion object : RegelFactory<SignifikantArenaHistorikkRegelInput> {
-        override val erAktiv = miljøConfig(prod = false, dev = true)
+        override val erAktiv = miljøConfig(prod = true, dev = true)
 
         override fun medDataInnhenting(
             repositoryProvider: RepositoryProvider,


### PR DESCRIPTION
Kjør ny Arenahistorikk-regel også i Prod, men ignorer utfallet av regelen.

Hensikten er å teste db-ytelsen i Prod, og med representative data. I Dev var det greit, men Prod har markert høyere antall rader enn Dev (Arena-Q2 databasen). 


AAP-1672