### PR TITLE
Logg når søknaden sendes Kelvin og den har Arena-historikk

### DIFF
--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/prosessering/FordelingRegelJobbUtfører.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/prosessering/FordelingRegelJobbUtfører.kt
@@ -120,9 +120,12 @@ class FordelingRegelJobbUtfører(
                         journalpost.mottattDato
                     )
                 )
+                if (res.skalTilKelvin() && res.medArenaHistorikk) {
+                    log.info("Søknad med journalpostId=${journalpost.journalpostId} og historikk i AAP-Arena sendes Kelvin.")
+                }
                 StatusMedÅrsakOgRegelresultat(
                     InnkommendeJournalpostStatus.EVALUERT,
-                    regelresultat = res
+                    regelresultat = res.verdi
                 )
             }
         }

--- a/flyt/src/test/kotlin/no/nav/aap/fordeler/regler/RegelResultatTest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/fordeler/regler/RegelResultatTest.kt
@@ -74,7 +74,7 @@ class RegelResultatTest {
                 "GeografiskTilknytningRegel" to true,
                 "MaksAntallPersonerIKelvinRegel" to true,
             ),
-            forJournalpost = 123L
+            forJournalpost = 123L,
         )
 
         assertThat(regelResultat.skalTilKelvin()).isFalse()
@@ -108,7 +108,7 @@ class RegelResultatTest {
                 "GeografiskTilknytningRegel" to false,
                 "MaksAntallPersonerIKelvinRegel" to true
             ),
-            forJournalpost = 123L
+            forJournalpost = 123L,
         )
 
         assertThat(regelResultat.skalTilKelvin()).isFalse()
@@ -149,7 +149,7 @@ class RegelResultatTest {
                 "ManueltOverstyrtTilArenaRegel" to false,
                 "SøknadRegel" to false,
             ),
-            forJournalpost = 123L
+            forJournalpost = 123L,
         )
         assertThat(annetDokumentMedKelvinSak.skalTilKelvin()).isTrue()
 

--- a/flyt/src/test/kotlin/no/nav/aap/fordeler/regler/RegelResultatTest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/fordeler/regler/RegelResultatTest.kt
@@ -74,7 +74,7 @@ class RegelResultatTest {
                 "GeografiskTilknytningRegel" to true,
                 "MaksAntallPersonerIKelvinRegel" to true,
             ),
-            forJournalpost = 123L,
+            forJournalpost = 123L
         )
 
         assertThat(regelResultat.skalTilKelvin()).isFalse()
@@ -108,7 +108,7 @@ class RegelResultatTest {
                 "GeografiskTilknytningRegel" to false,
                 "MaksAntallPersonerIKelvinRegel" to true
             ),
-            forJournalpost = 123L,
+            forJournalpost = 123L
         )
 
         assertThat(regelResultat.skalTilKelvin()).isFalse()
@@ -149,7 +149,7 @@ class RegelResultatTest {
                 "ManueltOverstyrtTilArenaRegel" to false,
                 "SøknadRegel" to false,
             ),
-            forJournalpost = 123L,
+            forJournalpost = 123L
         )
         assertThat(annetDokumentMedKelvinSak.skalTilKelvin()).isTrue()
 

--- a/flyt/src/test/kotlin/no/nav/aap/postmottak/prosessering/FordelingRegelJobbUtførerTest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/postmottak/prosessering/FordelingRegelJobbUtførerTest.kt
@@ -5,6 +5,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.aap.fordeler.Enhetsutreder
 import no.nav.aap.fordeler.FordelerRegelService
+import no.nav.aap.fordeler.IRegelResultat
 import no.nav.aap.fordeler.InnkommendeJournalpostStatus
 import no.nav.aap.fordeler.Regelresultat
 import no.nav.aap.motor.FlytJobbRepository
@@ -82,7 +83,7 @@ internal class FordelingRegelJobbUtførerTest {
 
         every { enhetsutreder.finnJournalføringsenhet(any()) } returns "1234"
         every { journalpostService.hentSafJournalpost(journalpostId) } returns journalpost
-        every { regelService.evaluer(any()) } returns regelResultat
+        every { regelService.evaluer(any()).verdi } returns regelResultat
 
         fordelingRegelJobbUtfører.utfør(
             JobbInput(FordelingRegelJobbUtfører)


### PR DESCRIPTION
Det er i dag vanskelig å følge med på i loggene hvilke søknader som går til Kelvin og som også har Arena-historikk. 
Man må ta journalPostId fra ett søk og bla gjennom resultater fra et annet søk. 

Her logges det sammen. Det var den enkleste fremgangsmåten jeg fant. 

På litt sikt når vi har implementert https://jira.adeo.no/browse/AAP-1833 
kan dette fjernes igjen, og vi logger i den nye koden, heller.  