### PR TITLE
Lagre at personen har sak i Arena, logg info om det

### DIFF
--- a/flyt/src/main/kotlin/no/nav/aap/fordeler/regler/ArenaSakRegel.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/fordeler/regler/ArenaSakRegel.kt
@@ -1,0 +1,33 @@
+package no.nav.aap.fordeler.regler
+
+import no.nav.aap.komponenter.gateway.GatewayProvider
+import no.nav.aap.lookup.repository.RepositoryProvider
+import no.nav.aap.postmottak.gateway.AapInternApiGateway
+
+class ArenaSakRegel : Regel<ArenaSakRegelInput> {
+    companion object : RegelFactory<ArenaSakRegelInput> {
+        override val erAktiv = miljøConfig(prod = true, dev = true)
+        override fun medDataInnhenting(repositoryProvider: RepositoryProvider, gatewayProvider: GatewayProvider) =
+            RegelMedInputgenerator(
+                ArenaSakRegel(),
+                ArenaSakRegelInputGenerator(gatewayProvider)
+            )
+    }
+
+    override fun vurder(input: ArenaSakRegelInput) = input.personEksistererIAAPArena
+
+    override fun regelNavn(): String {
+        return this::class.simpleName!!
+    }
+}
+
+class ArenaSakRegelInputGenerator(private val gatewayProvider: GatewayProvider) : InputGenerator<ArenaSakRegelInput> {
+    override fun generer(input: RegelInput): ArenaSakRegelInput {
+        val eksistererIArena = gatewayProvider.provide<AapInternApiGateway>().harAapSakIArena(input.person).eksisterer
+        return ArenaSakRegelInput(eksistererIArena)
+    }
+}
+
+data class ArenaSakRegelInput(
+    val personEksistererIAAPArena: Boolean,
+)

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/prosessering/FordelingRegelJobbUtfører.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/prosessering/FordelingRegelJobbUtfører.kt
@@ -122,10 +122,10 @@ class FordelingRegelJobbUtfører(
                         journalpost.mottattDato
                     )
                 )
-                val medArenaHistorikk = res.regelMap[ArenaSakRegel::class.simpleName]!!
                 val utenKelvinHistorikk = !res.regelMap[KelvinSakRegel::class.simpleName]!!
+                val medArenaHistorikk = res.regelMap[ArenaSakRegel::class.simpleName]!!
                 if (res.skalTilKelvin() && utenKelvinHistorikk && medArenaHistorikk) {
-                    log.info("Søknad med journalpostId=${journalpost.journalpostId} og historikk i AAP-Arena sendes Kelvin.")
+                    log.info("Søknad for person som finnes i Arena og ikke i Kelvin sendes til Kelvin. journalpostId=${journalpost.journalpostId}")
                 }
                 StatusMedÅrsakOgRegelresultat(
                     InnkommendeJournalpostStatus.EVALUERT,

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/prosessering/FordelingRegelJobbUtfører.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/prosessering/FordelingRegelJobbUtfører.kt
@@ -9,6 +9,8 @@ import no.nav.aap.fordeler.InnkommendeJournalpostRepository
 import no.nav.aap.fordeler.InnkommendeJournalpostStatus
 import no.nav.aap.fordeler.NavEnhet
 import no.nav.aap.fordeler.Regelresultat
+import no.nav.aap.fordeler.regler.ArenaSakRegel
+import no.nav.aap.fordeler.regler.KelvinSakRegel
 import no.nav.aap.fordeler.regler.RegelInput
 import no.nav.aap.fordeler.ÅrsakTilStatus
 import no.nav.aap.komponenter.gateway.GatewayProvider
@@ -120,12 +122,14 @@ class FordelingRegelJobbUtfører(
                         journalpost.mottattDato
                     )
                 )
-                if (res.skalTilKelvin() && res.medArenaHistorikk) {
+                val medArenaHistorikk = res.regelMap[ArenaSakRegel::class.simpleName]!!
+                val utenKelvinHistorikk = !res.regelMap[KelvinSakRegel::class.simpleName]!!
+                if (res.skalTilKelvin() && utenKelvinHistorikk && medArenaHistorikk) {
                     log.info("Søknad med journalpostId=${journalpost.journalpostId} og historikk i AAP-Arena sendes Kelvin.")
                 }
                 StatusMedÅrsakOgRegelresultat(
                     InnkommendeJournalpostStatus.EVALUERT,
-                    regelresultat = res.verdi
+                    regelresultat = res
                 )
             }
         }

--- a/flyt/src/test/kotlin/no/nav/aap/fordeler/regler/RegelResultatTest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/fordeler/regler/RegelResultatTest.kt
@@ -18,6 +18,7 @@ class RegelResultatTest {
             mapOf(
                 "ManueltOverstyrtTilArenaRegel" to true,
                 "KelvinSakRegel" to true,
+                "ArenaSakRegel" to false,
                 "ErIkkeReisestønadRegel" to true,
                 "ErIkkeAnkeRegel" to true,
                 "GeografiskTilknytningRegel" to true,
@@ -34,6 +35,7 @@ class RegelResultatTest {
         val regelResultat = Regelresultat(
             mapOf(
                 "KelvinSakRegel" to true,
+                "ArenaSakRegel" to false,
                 "ManueltOverstyrtTilArenaRegel" to false,
                 "ErIkkeReisestønadRegel" to true,
                 "ErIkkeAnkeRegel" to true,
@@ -51,6 +53,7 @@ class RegelResultatTest {
         val regelResultat = Regelresultat(
             mapOf(
                 "KelvinSakRegel" to false,
+                "ArenaSakRegel" to false,
                 "ManueltOverstyrtTilArenaRegel" to false,
                 "GeografiskTilknytningRegel" to true,
                 "ErIkkeReisestønadRegel" to true,
@@ -68,6 +71,7 @@ class RegelResultatTest {
         val regelResultat = Regelresultat(
             mapOf(
                 "KelvinSakRegel" to true,
+                "ArenaSakRegel" to false,
                 "ErIkkeReisestønadRegel" to false,
                 "ManueltOverstyrtTilArenaRegel" to false,
                 "ErIkkeAnkeRegel" to true,
@@ -85,6 +89,7 @@ class RegelResultatTest {
         val regelResultat = Regelresultat(
             mapOf(
                 "KelvinSakRegel" to true,
+                "ArenaSakRegel" to false,
                 "ManueltOverstyrtTilArenaRegel" to false,
                 "ErIkkeReisestønadRegel" to true,
                 "ErIkkeAnkeRegel" to false,
@@ -102,6 +107,7 @@ class RegelResultatTest {
         val regelResultat = Regelresultat(
             mapOf(
                 "KelvinSakRegel" to false,
+                "ArenaSakRegel" to false,
                 "ErIkkeReisestønadRegel" to true,
                 "ManueltOverstyrtTilArenaRegel" to false,
                 "ErIkkeAnkeRegel" to true,
@@ -119,6 +125,7 @@ class RegelResultatTest {
         val annetDokumentUtenKelvinSak = Regelresultat(
             mapOf(
                 "KelvinSakRegel" to false,
+                "ArenaSakRegel" to false,
                 "ErIkkeReisestønadRegel" to true,
                 "ErIkkeAnkeRegel" to true,
                 "ManueltOverstyrtTilArenaRegel" to false,
@@ -132,6 +139,7 @@ class RegelResultatTest {
         val søknadUtenKelvinSak = Regelresultat(
             mapOf(
                 "KelvinSakRegel" to false,
+                "ArenaSakRegel" to false,
                 "ErIkkeReisestønadRegel" to true,
                 "ErIkkeAnkeRegel" to true,
                 "ManueltOverstyrtTilArenaRegel" to false,
@@ -144,6 +152,7 @@ class RegelResultatTest {
         val annetDokumentMedKelvinSak = Regelresultat(
             mapOf(
                 "KelvinSakRegel" to true,
+                "ArenaSakRegel" to false,
                 "ErIkkeReisestønadRegel" to true,
                 "ErIkkeAnkeRegel" to true,
                 "ManueltOverstyrtTilArenaRegel" to false,
@@ -152,7 +161,6 @@ class RegelResultatTest {
             forJournalpost = 123L
         )
         assertThat(annetDokumentMedKelvinSak.skalTilKelvin()).isTrue()
-
 
     }
 }

--- a/flyt/src/test/kotlin/no/nav/aap/postmottak/prosessering/FordelingRegelJobbUtførerTest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/postmottak/prosessering/FordelingRegelJobbUtførerTest.kt
@@ -5,7 +5,6 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.aap.fordeler.Enhetsutreder
 import no.nav.aap.fordeler.FordelerRegelService
-import no.nav.aap.fordeler.IRegelResultat
 import no.nav.aap.fordeler.InnkommendeJournalpostStatus
 import no.nav.aap.fordeler.Regelresultat
 import no.nav.aap.motor.FlytJobbRepository
@@ -79,11 +78,19 @@ internal class FordelingRegelJobbUtførerTest {
             relevanteDatoer = emptyList()
         )
 
-        val regelResultat = Regelresultat(mapOf("yolo" to true), forJournalpost = journalpostId.referanse)
+        val regelResultat = Regelresultat(
+            mapOf(
+                "ArenaSakRegel" to false,
+                "KelvinSakRegel" to false,
+                "ErIkkeReisestønadRegel" to true,
+                "ErIkkeAnkeRegel" to true,
+                "yolo" to true
+            ), forJournalpost = journalpostId.referanse
+        )
 
         every { enhetsutreder.finnJournalføringsenhet(any()) } returns "1234"
         every { journalpostService.hentSafJournalpost(journalpostId) } returns journalpost
-        every { regelService.evaluer(any()).verdi } returns regelResultat
+        every { regelService.evaluer(any()) } returns regelResultat
 
         fordelingRegelJobbUtfører.utfør(
             JobbInput(FordelingRegelJobbUtfører)

--- a/flyt/src/test/kotlin/no/nav/aap/postmottak/prosessering/FordelingVideresendJobbUtførerTest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/postmottak/prosessering/FordelingVideresendJobbUtførerTest.kt
@@ -36,7 +36,8 @@ class FordelingVideresendJobbUtførerTest {
                 "Regel2" to true,
                 "ErIkkeReisestønadRegel" to true,
                 "ErIkkeAnkeRegel" to true,
-                "KelvinSakRegel" to false
+                "KelvinSakRegel" to false,
+                "ArenaSakRegel" to false
             ),
             forJournalpost = 1L
         )

--- a/repository/src/test/kotlin/no/nav/aap/postmottak/repository/fordeler/InnkommendeJournalpostRepositoryImplTest.kt
+++ b/repository/src/test/kotlin/no/nav/aap/postmottak/repository/fordeler/InnkommendeJournalpostRepositoryImplTest.kt
@@ -61,6 +61,7 @@ class InnkommendeJournalpostRepositoryImplTest {
             regelresultat = Regelresultat(
                 mapOf(
                     "KelvinSakRegel" to false,
+                    "ArenaSakRegel" to false,
                     "ErIkkeReisestønadRegel" to true,
                     "ErIkkeAnkeRegel" to true,
                     "yolo" to true
@@ -107,6 +108,7 @@ class InnkommendeJournalpostRepositoryImplTest {
             regelresultat = Regelresultat(
                 mapOf(
                     "KelvinSakRegel" to false,
+                    "ArenaSakRegel" to false,
                     "ErIkkeReisestønadRegel" to true,
                     "ErIkkeAnkeRegel" to true,
                     "yolo" to true


### PR DESCRIPTION
Introduser ArenaSakRegel. Tilsvarer KelvinSakRegel. Brukes til å lagre informasjon om at personen har sak i Arena og logge dette.

Etter forslag fra @FredrikMeyer. 

Jeg prøvde et par andre strategier, men de ble ikke like bra; legge til et API i behandlingsflyt for å sjekke om personen finnes i Kelvin, endre behandlingsflyt saksApi til å si om sak ble opprettet eller ikke. 