### PR TITLE
Arena/sjekk alltid for signifikante saker

### DIFF
--- a/flyt/src/main/kotlin/no/nav/aap/fordeler/arena/jobber/SendSøknadTilArenaJobbUtfører.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/fordeler/arena/jobber/SendSøknadTilArenaJobbUtfører.kt
@@ -1,7 +1,6 @@
 package no.nav.aap.fordeler.arena.jobber
 
 import io.micrometer.core.instrument.MeterRegistry
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import no.nav.aap.fordeler.arena.ArenaGateway
 import no.nav.aap.fordeler.arena.ArenaOppgaveType
 import no.nav.aap.fordeler.arena.ArenaOpprettOppgaveForespørsel
@@ -36,7 +35,7 @@ class SendSøknadTilArenaJobbUtfører(
 
         override val type = "arena.søknad"
 
-        override val navn = "Søknad til Arean Håndterer"
+        override val navn = "Søknad til Arena -håndterer"
 
         override val beskrivelse = "Oppretter sak i Arena for ny søknad"
 
@@ -62,10 +61,10 @@ class SendSøknadTilArenaJobbUtfører(
                 titler = kontekst.vedleggstitler,
                 oppgaveType = ArenaOppgaveType.STARTVEDTAK
             )
-            val respons = arenaKlient.opprettArenaOppgave(request)
-            requireNotNull(respons.arenaSakId) { "Mangler saksnummer fra Arena" }
-            log.info("Opprettet oppgave med id ${respons.oppgaveId} på sak ${respons.arenaSakId}")
-            opprettAutomatiskJournalføringsjobb(kontekst, respons.arenaSakId)
+            val arenaOppgave = arenaKlient.opprettArenaOppgave(request)
+            requireNotNull(arenaOppgave.arenaSakId) { "Mangler saksnummer fra Arena" }
+            log.info("Opprettet oppgave med id ${arenaOppgave.oppgaveId} på sak ${arenaOppgave.arenaSakId}")
+            opprettAutomatiskJournalføringsjobb(kontekst, arenaOppgave.arenaSakId)
         } else {
             log.info("Det finnes alt en sak i Arena, sender journalpost til manuell journalføring")
             opprettManuellJournalføringsoppgavejobb(kontekst)

--- a/flyt/src/main/kotlin/no/nav/aap/fordeler/regler/ArenaHistorikkRegel.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/fordeler/regler/ArenaHistorikkRegel.kt
@@ -56,6 +56,7 @@ class ArenaHistorikkRegelInputGenerator(private val gatewayProvider: GatewayProv
 
         val signifikantHistorikk = apiInternGateway.harSignifikantHistorikkIAAPArena(input.person, input.mottattDato)
         PrometheusProvider.prometheus.sperretAvArenaHistorikkFilterTeller(signifikantHistorikk.harSignifikantHistorikk)
+            .increment()
 
         if (signifikantHistorikk.harSignifikantHistorikk) {
             logger.info(

--- a/flyt/src/main/kotlin/no/nav/aap/fordeler/regler/ArenaHistorikkRegel.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/fordeler/regler/ArenaHistorikkRegel.kt
@@ -7,6 +7,7 @@ import no.nav.aap.postmottak.PrometheusProvider
 import no.nav.aap.postmottak.gateway.AapInternApiGateway
 import no.nav.aap.postmottak.journalpostogbehandling.journalpost.Person
 import no.nav.aap.postmottak.personFinnesIArena
+import no.nav.aap.postmottak.sperretAvArenaHistorikkFilterTeller
 import no.nav.aap.unleash.PostmottakFeature
 import no.nav.aap.unleash.UnleashGateway
 import org.slf4j.LoggerFactory
@@ -54,6 +55,7 @@ class ArenaHistorikkRegelInputGenerator(private val gatewayProvider: GatewayProv
         )
 
         val signifikantHistorikk = apiInternGateway.harSignifikantHistorikkIAAPArena(input.person, input.mottattDato)
+        PrometheusProvider.prometheus.sperretAvArenaHistorikkFilterTeller(signifikantHistorikk.harSignifikantHistorikk)
 
         if (signifikantHistorikk.harSignifikantHistorikk) {
             logger.info(
@@ -68,7 +70,8 @@ class ArenaHistorikkRegelInputGenerator(private val gatewayProvider: GatewayProv
         }
 
         val resultat = if (!nyttFilterAktivt) {
-            // bruker gradual rollout av nytt filter
+            // Vi gjør gradual rollout av nytt filter.
+            // Kall derfor gammelt filter når det nye ikke er aktivt for personen.
             apiInternGateway.harAapSakIArena(input.person).eksisterer
         } else {
             signifikantHistorikk.harSignifikantHistorikk

--- a/flyt/src/main/kotlin/no/nav/aap/fordeler/regler/ArenaHistorikkRegel.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/fordeler/regler/ArenaHistorikkRegel.kt
@@ -4,9 +4,9 @@ import no.nav.aap.fordeler.regler.ArenaHistorikkRegel.Companion.tellArenaHistori
 import no.nav.aap.komponenter.gateway.GatewayProvider
 import no.nav.aap.lookup.repository.RepositoryProvider
 import no.nav.aap.postmottak.PrometheusProvider
-import no.nav.aap.postmottak.personFinnesIArena
 import no.nav.aap.postmottak.gateway.AapInternApiGateway
 import no.nav.aap.postmottak.journalpostogbehandling.journalpost.Person
+import no.nav.aap.postmottak.personFinnesIArena
 import no.nav.aap.unleash.PostmottakFeature
 import no.nav.aap.unleash.UnleashGateway
 import org.slf4j.LoggerFactory
@@ -53,34 +53,28 @@ class ArenaHistorikkRegelInputGenerator(private val gatewayProvider: GatewayProv
             input.person.identifikator.toString() // gradual rollout er sticky på userId
         )
 
-        val personenFinnesIAapArena = apiInternGateway.harAapSakIArena(input.person).eksisterer
+        val signifikantHistorikk = apiInternGateway.harSignifikantHistorikkIAAPArena(input.person, input.mottattDato)
 
-        // Hvis det opprinnelige filteret finner en person, spør vi også det nye filteret dersom det er enabled.
-        // Dette gir en gradual rollout av det nye filteret, som en økning av saker oppå det gamle filteret.
-        if (personenFinnesIAapArena && nyttFilterAktivt) {
-            val nyttFilter = apiInternGateway.harSignifikantHistorikkIAAPArena(input.person, input.mottattDato)
-            if (nyttFilter.harSignifikantHistorikk) {
-                logger.info(
-                    "Personen har signifikant historikk i AAP-Arena: " +
-                            "saker=${nyttFilter.signifikanteSaker}, journalpostId=${input.journalpostId}"
-                )
-            } else {
-                logger.info(
-                    "Personen har /IKKE/ signifikant historikk i AAP-Arena: " +
-                            "journalpostId=${input.journalpostId}"
-                )
-            }
-
-            return ArenaHistorikkRegelInput(
-                nyttFilter.harSignifikantHistorikk,
-                input.person
-            ).also {
-                tellArenaHistorikk(nyttFilter.harSignifikantHistorikk)
-            }
+        if (signifikantHistorikk.harSignifikantHistorikk) {
+            logger.info(
+                "Personen har signifikant historikk i AAP-Arena: " +
+                        "saker=${signifikantHistorikk.signifikanteSaker}, journalpostId=${input.journalpostId}"
+            )
+        } else {
+            logger.info(
+                "Personen har /IKKE/ signifikant historikk i AAP-Arena: " +
+                        "journalpostId=${input.journalpostId}"
+            )
         }
 
-        return ArenaHistorikkRegelInput(personenFinnesIAapArena, input.person).also {
-            tellArenaHistorikk(personenFinnesIAapArena)
+        val resultat = if (!nyttFilterAktivt) {
+            // bruker gradual rollout av nytt filter
+            apiInternGateway.harAapSakIArena(input.person).eksisterer
+        } else {
+            signifikantHistorikk.harSignifikantHistorikk
+        }
+        return ArenaHistorikkRegelInput(resultat, input.person).also {
+            tellArenaHistorikk(resultat)
         }
     }
 }

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/PrometheusProvider.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/PrometheusProvider.kt
@@ -59,6 +59,15 @@ fun MeterRegistry.regelresultat(tilKelvin: Boolean, regel: String): Counter =
 fun MeterRegistry.retriesExceeded(jobbType: String): Counter =
     this.counter("postmottak_retries_exceeded", listOf(Tag.of("jobb_type", jobbType)))
 
+fun MeterRegistry.resultatMedArenaHistorikkTeller(fagsystem: Fagsystem) {
+    this.counter("postmottak_fordeling_ved_arenahistorikk", listOf(Tag.of("fagsystem", fagsystem.name)))
+}
+
+fun MeterRegistry.sperretAvArenaHistorikkFilterTeller(sperret: Boolean) {
+    this.counter("postmottak_sperret_av_arenahistorikk_filter", listOf(Tag.of("sperret", sperret.toString())))
+}
+
+
 enum class Fagsystem {
     arena,
     kelvin

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/PrometheusProvider.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/PrometheusProvider.kt
@@ -59,13 +59,11 @@ fun MeterRegistry.regelresultat(tilKelvin: Boolean, regel: String): Counter =
 fun MeterRegistry.retriesExceeded(jobbType: String): Counter =
     this.counter("postmottak_retries_exceeded", listOf(Tag.of("jobb_type", jobbType)))
 
-fun MeterRegistry.resultatMedArenaHistorikkTeller(fagsystem: Fagsystem) {
+fun MeterRegistry.resultatMedArenaHistorikkTeller(fagsystem: Fagsystem) =
     this.counter("postmottak_fordeling_ved_arenahistorikk", listOf(Tag.of("fagsystem", fagsystem.name)))
-}
 
-fun MeterRegistry.sperretAvArenaHistorikkFilterTeller(sperret: Boolean) {
+fun MeterRegistry.sperretAvArenaHistorikkFilterTeller(sperret: Boolean) =
     this.counter("postmottak_sperret_av_arenahistorikk_filter", listOf(Tag.of("sperret", sperret.toString())))
-}
 
 
 enum class Fagsystem {

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/prosessering/FordelingRegelJobbUtfører.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/prosessering/FordelingRegelJobbUtfører.kt
@@ -168,7 +168,7 @@ class FordelingRegelJobbUtfører(
         }
         val fagsystem = if (skalTilKelvin) Fagsystem.kelvin else Fagsystem.arena
         log.info("Søknad for person som finnes i Arena og ikke i Kelvin sendes til ${fagsystem}. journalpostId=${journalpost.journalpostId}")
-        prometheus.resultatMedArenaHistorikkTeller(fagsystem)
+        prometheus.resultatMedArenaHistorikkTeller(fagsystem).increment()
     }
 
     private fun hentEnhet(safJournalpost: SafJournalpost): NavEnhet? {

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/prosessering/FordelingRegelJobbUtfører.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/prosessering/FordelingRegelJobbUtfører.kt
@@ -19,6 +19,7 @@ import no.nav.aap.motor.FlytJobbRepository
 import no.nav.aap.motor.JobbInput
 import no.nav.aap.motor.JobbUtfører
 import no.nav.aap.motor.ProvidersJobbSpesifikasjon
+import no.nav.aap.postmottak.Fagsystem
 import no.nav.aap.postmottak.PrometheusProvider
 import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.JournalpostService
 import no.nav.aap.postmottak.gateway.BrukerIdType
@@ -28,7 +29,9 @@ import no.nav.aap.postmottak.gateway.SafJournalpost
 import no.nav.aap.postmottak.gateway.hoveddokument
 import no.nav.aap.postmottak.gateway.originalFiltype
 import no.nav.aap.postmottak.journalpostCounter
+import no.nav.aap.postmottak.journalpostogbehandling.journalpost.Journalpost
 import no.nav.aap.postmottak.kontrakt.journalpost.JournalpostId
+import no.nav.aap.postmottak.resultatMedArenaHistorikkTeller
 import org.slf4j.LoggerFactory
 
 class FordelingRegelJobbUtfører(
@@ -124,9 +127,7 @@ class FordelingRegelJobbUtfører(
                 )
                 val utenKelvinHistorikk = !res.regelMap[KelvinSakRegel::class.simpleName]!!
                 val medArenaHistorikk = res.regelMap[ArenaSakRegel::class.simpleName]!!
-                if (res.skalTilKelvin() && utenKelvinHistorikk && medArenaHistorikk) {
-                    log.info("Søknad for person som finnes i Arena og ikke i Kelvin sendes til Kelvin. journalpostId=${journalpost.journalpostId}")
-                }
+                tellFordelingsresultatMedArenaHistorikk(res.skalTilKelvin(), utenKelvinHistorikk, medArenaHistorikk, journalpost)
                 StatusMedÅrsakOgRegelresultat(
                     InnkommendeJournalpostStatus.EVALUERT,
                     regelresultat = res
@@ -153,6 +154,21 @@ class FordelingRegelJobbUtfører(
         if (statusMedÅrsakOgRegelresultat.status == InnkommendeJournalpostStatus.EVALUERT) {
             opprettVideresendJobb(id, journalpostId)
         }
+    }
+
+    private fun tellFordelingsresultatMedArenaHistorikk(
+        skalTilKelvin: Boolean,
+        utenKelvinHistorikk: Boolean,
+        medArenaHistorikk: Boolean,
+        journalpost: Journalpost
+    ) {
+        val nyIKelvinFinnesIArena = utenKelvinHistorikk && medArenaHistorikk
+        if (!nyIKelvinFinnesIArena) {
+            return
+        }
+        val fagsystem = if (skalTilKelvin) Fagsystem.kelvin else Fagsystem.arena
+        log.info("Søknad for person som finnes i Arena og ikke i Kelvin sendes til ${fagsystem}. journalpostId=${journalpost.journalpostId}")
+        prometheus.resultatMedArenaHistorikkTeller(fagsystem)
     }
 
     private fun hentEnhet(safJournalpost: SafJournalpost): NavEnhet? {


### PR DESCRIPTION
- Kall alltid på arenaoppslag for å undersøke om det er signifikante vedtak som hindrer søknaden fra å behandles i Kelvin. Fortsett å begrense hvor ofte denne logikken påvirker fordelingen til Kelvin som før. 
- Tell forekomst av signifikante vedtak og slutt-utfallet av fordelingen.

[AAPM-42](https://jira.adeo.no/browse/AAPM-42)