### PR TITLE
arenahistorikk-metrikk bare for søknader

### DIFF
--- a/flyt/src/main/kotlin/no/nav/aap/fordeler/FordelerRegelService.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/fordeler/FordelerRegelService.kt
@@ -11,7 +11,6 @@ import no.nav.aap.fordeler.regler.RegelInput
 import no.nav.aap.komponenter.gateway.GatewayProvider
 import no.nav.aap.lookup.repository.RepositoryProvider
 import no.nav.aap.postmottak.PrometheusProvider
-import no.nav.aap.postmottak.gateway.AapInternApiGateway
 import no.nav.aap.postmottak.regelresultat
 import org.slf4j.LoggerFactory
 

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/PrometheusProvider.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/PrometheusProvider.kt
@@ -59,7 +59,7 @@ fun MeterRegistry.regelresultat(tilKelvin: Boolean, regel: String): Counter =
 fun MeterRegistry.retriesExceeded(jobbType: String): Counter =
     this.counter("postmottak_retries_exceeded", listOf(Tag.of("jobb_type", jobbType)))
 
-fun MeterRegistry.resultatMedArenaHistorikkTeller(fagsystem: Fagsystem) =
+fun MeterRegistry.fordelingVedArenaHistorikkCounter(fagsystem: Fagsystem) =
     this.counter("postmottak_fordeling_ved_arenahistorikk", listOf(Tag.of("fagsystem", fagsystem.name)))
 
 fun MeterRegistry.sperretAvArenaHistorikkFilterTeller(sperret: Boolean) =

--- a/flyt/src/test/kotlin/no/nav/aap/postmottak/prosessering/FordelingRegelJobbUtførerTest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/postmottak/prosessering/FordelingRegelJobbUtførerTest.kt
@@ -20,6 +20,7 @@ import no.nav.aap.postmottak.gateway.SafDokumentvariant
 import no.nav.aap.postmottak.gateway.SafJournalpost
 import no.nav.aap.postmottak.gateway.SafVariantformat
 import no.nav.aap.postmottak.kontrakt.journalpost.JournalpostId
+import no.nav.aap.postmottak.prosessering.TestObjekter.lagTestJournalpost
 import no.nav.aap.postmottak.repository.fordeler.InnkommendeJournalpostRepositoryImpl
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -57,26 +58,7 @@ internal class FordelingRegelJobbUtførerTest {
     fun `når jobben er utført finnes det et regel resultat for journalposten`() {
         val journalpostId = JournalpostId(1L)
 
-        val journalpost = SafJournalpost(
-            journalpostId = journalpostId.referanse,
-            bruker = Bruker(
-                id = "fnr",
-                type = BrukerIdType.FNR,
-            ),
-            dokumenter = listOf(
-                SafDokumentInfo(
-                    dokumentInfoId = "1",
-                    brevkode = "NAV 11-13.05",
-                    tittel = "tittel",
-                    dokumentvarianter = listOf(
-                        SafDokumentvariant(variantformat = SafVariantformat.ORIGINAL, filtype = "json")
-                    )
-                )
-            ),
-            journalstatus = Journalstatus.MOTTATT,
-            tema = Tema.AAP.name,
-            relevanteDatoer = emptyList()
-        )
+        val journalpost = lagTestJournalpost(journalpostId)
 
         val regelResultat = Regelresultat(
             mapOf(

--- a/flyt/src/test/kotlin/no/nav/aap/postmottak/prosessering/FordelingVideresendJobbUtførerTest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/postmottak/prosessering/FordelingVideresendJobbUtførerTest.kt
@@ -7,9 +7,11 @@ import no.nav.aap.fordeler.RegelRepository
 import no.nav.aap.fordeler.Regelresultat
 import no.nav.aap.motor.FlytJobbRepository
 import no.nav.aap.motor.JobbInput
+import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.JournalpostService
 import no.nav.aap.postmottak.journalpostogbehandling.behandling.BehandlingRepository
 import no.nav.aap.postmottak.kontrakt.behandling.TypeBehandling
 import no.nav.aap.postmottak.kontrakt.journalpost.JournalpostId
+import no.nav.aap.postmottak.prosessering.TestObjekter.lagTestJournalpost
 import no.nav.aap.postmottak.test.Fakes
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -19,17 +21,19 @@ class FordelingVideresendJobbUtførerTest {
     val behandlingRepositoryMock = mockk<BehandlingRepository>(relaxed = true)
     val regelRepositoryMock = mockk<RegelRepository>()
     val flytJobbRepositoryMock = mockk<FlytJobbRepository>(relaxed = true)
+    val journalpostServiceMock = mockk<JournalpostService>(relaxed = true)
     val fordelingVideresendJobbUtfører =
         FordelingVideresendJobbUtfører(
             behandlingRepository = behandlingRepositoryMock,
             regelRepository = regelRepositoryMock,
             flytJobbRepository = flytJobbRepositoryMock,
             arenaVideresender = mockk(),
-            journalpostService = mockk(relaxed = true)
+            journalpostService = journalpostServiceMock
         )
 
     @Test
     fun `Når journalposten skal til Kelvin skal vi opprette en ProsesserBehandlingJobb`() {
+        val testJournalpostId = 1L
         val regelResultat = Regelresultat(
             regelMap = mapOf(
                 "Regel1" to true,
@@ -39,15 +43,16 @@ class FordelingVideresendJobbUtførerTest {
                 "KelvinSakRegel" to false,
                 "ArenaSakRegel" to false
             ),
-            forJournalpost = 1L
+            forJournalpost = testJournalpostId
         )
-        val journalpostId = JournalpostId(1)
+        val journalpostId = JournalpostId(testJournalpostId)
         every { regelRepositoryMock.hentRegelresultat(journalpostId) } returns regelResultat
+        every { journalpostServiceMock.hentSafJournalpost(journalpostId) } returns lagTestJournalpost(journalpostId)
 
         val jobbInput = JobbInput(FordelingVideresendJobbUtfører)
             .forSak(journalpostId.referanse)
             .medJournalpostId(journalpostId)
-            .medInnkommendeJournalpostId(1L)
+            .medInnkommendeJournalpostId(testJournalpostId)
         fordelingVideresendJobbUtfører.utfør(jobbInput)
 
         assertThat(

--- a/flyt/src/test/kotlin/no/nav/aap/postmottak/prosessering/TestObjekter.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/postmottak/prosessering/TestObjekter.kt
@@ -1,0 +1,37 @@
+package no.nav.aap.postmottak.prosessering
+
+import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.tema.Tema
+import no.nav.aap.postmottak.gateway.Bruker
+import no.nav.aap.postmottak.gateway.BrukerIdType
+import no.nav.aap.postmottak.gateway.Journalstatus
+import no.nav.aap.postmottak.gateway.SafDokumentInfo
+import no.nav.aap.postmottak.gateway.SafDokumentvariant
+import no.nav.aap.postmottak.gateway.SafJournalpost
+import no.nav.aap.postmottak.gateway.SafVariantformat
+import no.nav.aap.postmottak.journalpostogbehandling.journalpost.Brevkoder
+import no.nav.aap.postmottak.kontrakt.journalpost.JournalpostId
+
+internal object TestObjekter {
+
+    fun lagTestJournalpost(journalpostId: JournalpostId): SafJournalpost = SafJournalpost(
+        journalpostId = journalpostId.referanse,
+        bruker = Bruker(
+            id = "fnr",
+            type = BrukerIdType.FNR,
+        ),
+        dokumenter = listOf(
+            SafDokumentInfo(
+                dokumentInfoId = "1",
+                brevkode = Brevkoder.SØKNAD.kode,
+                tittel = "tittel",
+                dokumentvarianter = listOf(
+                    SafDokumentvariant(variantformat = SafVariantformat.ORIGINAL, filtype = "json")
+                )
+            )
+        ),
+        journalstatus = Journalstatus.MOTTATT,
+        tema = Tema.AAP.name,
+        relevanteDatoer = emptyList()
+    )
+
+}


### PR DESCRIPTION
Her flytter jeg noe kode jeg la til nylig, og legger til et kriterie for den nye arenahistorikk-metrikken om at det må være søknader. Dette fikser en tellefeil i metrikken. 

AAPM-42