### PR TITLE
Korriger metrikken postmottak_person_finnes_i_aap_arena

### DIFF
--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/PrometheusProvider.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/PrometheusProvider.kt
@@ -53,17 +53,23 @@ fun MeterRegistry.regelresultat(tilKelvin: Boolean, regel: String): Counter =
 fun MeterRegistry.retriesExceeded(jobbType: String): Counter =
     this.counter("postmottak_retries_exceeded", listOf(Tag.of("jobb_type", jobbType)))
 
-fun MeterRegistry.personFinnesIArena(finnes: Boolean): Counter =
+fun MeterRegistry.personFinnesIAapArenaTeller(finnes: Boolean): Counter = this.counter(
+    "postmottak_person_finnes_i_aap_arena", listOf(Tag.of("verdi", finnes.toString()))
+)
+
+fun MeterRegistry.fordelingAvSoknadVedArenaHistorikkCounter(fagsystem: Fagsystem): Counter = this.counter(
+    "postmottak_fordeling_av_soknad_ved_arenahistorikk", listOf(Tag.of("fagsystem", fagsystem.name))
+)
+
+fun MeterRegistry.signifikantArenaHistorikkTeller(sperretAvFilter: Boolean): Counter = this.counter(
+    "postmottak_sperret_av_arenahistorikk_filter", listOf(Tag.of("sperret", sperretAvFilter.toString()))
+)
+
+fun MeterRegistry.resultatAvSignifikantArenaHistorikkFilterTeller(harSignifikantHistorikk: Boolean): Counter =
     this.counter(
-        "postmottak_person_finnes_i_aap_arena",
-        listOf(Tag.of("verdi", finnes.toString()))
+        "postmottak_arenaperson_har_signifikant_historikk",
+        listOf(Tag.of("signifikant", harSignifikantHistorikk.toString()))
     )
-
-fun MeterRegistry.fordelingVedArenaHistorikkCounter(fagsystem: Fagsystem) =
-    this.counter("postmottak_fordeling_ved_arenahistorikk", listOf(Tag.of("fagsystem", fagsystem.name)))
-
-fun MeterRegistry.sperretAvArenaHistorikkFilterTeller(sperret: Boolean) =
-    this.counter("postmottak_sperret_av_arenahistorikk_filter", listOf(Tag.of("sperret", sperret.toString())))
 
 
 enum class Fagsystem {

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/PrometheusProvider.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/PrometheusProvider.kt
@@ -47,17 +47,17 @@ fun MeterRegistry.journalføringCounter(type: JournalføringsType, enhet: NavEnh
 fun MeterRegistry.ubehandledeJournalposterCounter(kildesystem: String): Counter =
     this.counter("postmottak_journalposter_ubehandlet", listOf(Tag.of("kildesystem", kildesystem)))
 
-fun MeterRegistry.personFinnesIArena(medSignifikantHistorikk: Boolean): Counter =
-    this.counter(
-        "postmottak_person_finnes_i_aap_arena",
-        listOf(Tag.of("signifikant_historikk", medSignifikantHistorikk.toString()))
-    )
-
 fun MeterRegistry.regelresultat(tilKelvin: Boolean, regel: String): Counter =
     this.counter("postmottak_regelresultat", listOf(Tag.of("regel", regel), Tag.of("til_kelvin", tilKelvin.toString())))
 
 fun MeterRegistry.retriesExceeded(jobbType: String): Counter =
     this.counter("postmottak_retries_exceeded", listOf(Tag.of("jobb_type", jobbType)))
+
+fun MeterRegistry.personFinnesIArena(finnes: Boolean): Counter =
+    this.counter(
+        "postmottak_person_finnes_i_aap_arena",
+        listOf(Tag.of("verdi", finnes.toString()))
+    )
 
 fun MeterRegistry.fordelingVedArenaHistorikkCounter(fagsystem: Fagsystem) =
     this.counter("postmottak_fordeling_ved_arenahistorikk", listOf(Tag.of("fagsystem", fagsystem.name)))

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/prosessering/FordelingVideresendJobbUtfører.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/prosessering/FordelingVideresendJobbUtfører.kt
@@ -23,7 +23,7 @@ import no.nav.aap.postmottak.journalpostogbehandling.behandling.BehandlingReposi
 import no.nav.aap.postmottak.journalpostogbehandling.journalpost.Brevkoder
 import no.nav.aap.postmottak.kontrakt.behandling.TypeBehandling
 import no.nav.aap.postmottak.kontrakt.journalpost.JournalpostId
-import no.nav.aap.postmottak.fordelingVedArenaHistorikkCounter
+import no.nav.aap.postmottak.fordelingAvSoknadVedArenaHistorikkCounter
 import org.slf4j.LoggerFactory
 
 private val log = LoggerFactory.getLogger(FordelingVideresendJobbUtfører::class.java)
@@ -93,7 +93,7 @@ class FordelingVideresendJobbUtfører(
                 "Søknad for person som finnes i Arena og ikke i Kelvin sendes til ${fagsystem}. " +
                         "journalpostId=${journalpost.journalpostId}"
             )
-            prometheus.fordelingVedArenaHistorikkCounter(fagsystem).increment()
+            prometheus.fordelingAvSoknadVedArenaHistorikkCounter(fagsystem).increment()
         }
     }
 


### PR DESCRIPTION
Metrikken ble brukt for inntaksfilteret, og ikke for eksistens i Arena som tiltenkt

AAPM-42