### PR TITLE
Implementerer støtte for å håndtere journalposter med status FEILREGISTRERT fra Kafka

### DIFF
--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/gateway/BehandlingsflytGateway.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/gateway/BehandlingsflytGateway.kt
@@ -34,6 +34,11 @@ interface BehandlingsflytGateway : Gateway {
     )
 
     fun finnKlagebehandlinger(saksnummer: Saksnummer): List<Klagebehandling>
+
+    fun sendFeilregistrertHendelse(
+        journalpostId: JournalpostId,
+        saksnummer: String,
+    )
 }
 
 data class BehandlingsflytSak(

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/mottak/KafkaStreams.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/mottak/KafkaStreams.kt
@@ -86,23 +86,23 @@ class JoarkKafkaHandler(
     init {
         val journalfoeringHendelseAvro = JournalfoeringHendelseAvro(config)
         val streamBuilder = StreamsBuilder()
-
-        val baseStream = streamBuilder.stream(JOARK_TOPIC, Consumed.with(Serdes.String(), journalfoeringHendelseAvro.avroserdes))
+        
+        streamBuilder.stream(JOARK_TOPIC, Consumed.with(Serdes.String(), journalfoeringHendelseAvro.avroserdes))
             .filter(erIkkeKanalEESSI)
-
-        // Håndter journalposter med status MOTTATT
-        baseStream
-            .filter(harStatusMottatt)
-            .peek { _, record -> prometheus.hendelseType(record) }
             .split()
-            .branch(erTemaEndretFraAAP, Branched.withConsumer(::temaendringTopology))
-            .branch(erTemaAAP, Branched.withConsumer(::nyJournalpost))
-
-        // Håndter journalposter med status FEILREGISTRERT
-        baseStream
-            .filter(harStatusFeilregistrert)
-            .filter(erTemaAAP)
-            .foreach { _, record -> håndterFeilregistrertJournalpost(record) }
+            .branch(harStatusMottatt, Branched.withConsumer { stream ->
+                stream
+                    .peek { _, record -> prometheus.hendelseType(record) }
+                    .split()
+                    .branch(erTemaEndretFraAAP, Branched.withConsumer(::temaendringTopology))
+                    .branch(erTemaAAP, Branched.withConsumer(::nyJournalpost))
+            })
+            .branch(harStatusFeilregistrert, Branched.withConsumer { stream ->
+                stream
+                    .peek { _, record -> prometheus.hendelseType(record) }
+                    .filter(erTemaAAP)
+                    .foreach { _, record -> håndterFeilregistrertJournalpost(record) }
+            })
 
         topology = streamBuilder.build()
 
@@ -171,6 +171,7 @@ class JoarkKafkaHandler(
                     log.info("Fant åpen behandling for feilregistrert journalpost $journalpostId - trigger prosessering")
                     triggProsesserBehandling(journalpostId, åpenBehandling)
                 }
+
                 behandlinger.isNotEmpty() -> {
                     log.info("Alle behandlinger avsluttet for feilregistrert journalpost $journalpostId - oppretter jobb")
                     flytJobbRepository.leggTil(
@@ -179,6 +180,7 @@ class JoarkKafkaHandler(
                             .medJournalpostId(journalpostId)
                     )
                 }
+
                 else -> {
                     log.info("Ingen behandlinger funnet for feilregistrert journalpost $journalpostId - ignorerer")
                 }

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/mottak/KafkaStreams.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/mottak/KafkaStreams.kt
@@ -16,8 +16,10 @@ import no.nav.aap.postmottak.kontrakt.journalpost.JournalpostId
 import no.nav.aap.postmottak.mottak.JoarkRegel.erIkkeKanalEESSI
 import no.nav.aap.postmottak.mottak.JoarkRegel.erTemaAAP
 import no.nav.aap.postmottak.mottak.JoarkRegel.erTemaEndretFraAAP
+import no.nav.aap.postmottak.mottak.JoarkRegel.harStatusFeilregistrert
 import no.nav.aap.postmottak.mottak.JoarkRegel.harStatusMottatt
 import no.nav.aap.postmottak.mottak.kafka.config.StreamsConfig
+import no.nav.aap.postmottak.prosessering.FeilregistrertJournalpostJobbUtfører
 import no.nav.aap.postmottak.prosessering.FordelingRegelJobbUtfører
 import no.nav.aap.postmottak.prosessering.ProsesserBehandlingJobbUtfører
 import no.nav.aap.postmottak.prosessering.medJournalpostId
@@ -85,13 +87,22 @@ class JoarkKafkaHandler(
         val journalfoeringHendelseAvro = JournalfoeringHendelseAvro(config)
         val streamBuilder = StreamsBuilder()
 
-        streamBuilder.stream(JOARK_TOPIC, Consumed.with(Serdes.String(), journalfoeringHendelseAvro.avroserdes))
-            .filter(harStatusMottatt)
+        val baseStream = streamBuilder.stream(JOARK_TOPIC, Consumed.with(Serdes.String(), journalfoeringHendelseAvro.avroserdes))
             .filter(erIkkeKanalEESSI)
+
+        // Håndter journalposter med status MOTTATT
+        baseStream
+            .filter(harStatusMottatt)
             .peek { _, record -> prometheus.hendelseType(record) }
             .split()
             .branch(erTemaEndretFraAAP, Branched.withConsumer(::temaendringTopology))
             .branch(erTemaAAP, Branched.withConsumer(::nyJournalpost))
+
+        // Håndter journalposter med status FEILREGISTRERT
+        baseStream
+            .filter(harStatusFeilregistrert)
+            .filter(erTemaAAP)
+            .foreach { _, record -> håndterFeilregistrertJournalpost(record) }
 
         topology = streamBuilder.build()
 
@@ -138,6 +149,43 @@ class JoarkKafkaHandler(
         }
     }
 
+    /**
+     * Håndterer journalposter med status FEILREGISTRERT.
+     *
+     * Hvis det finnes en åpen behandling, trigges prosessering slik at stegene
+     * kan oppdage at journalposten er feilregistrert og avslutte behandlingen.
+     *
+     * Hvis alle behandlinger er avsluttet, opprettes en jobb som sender
+     * feilregistrert-hendelse til behandlingsflyt (dersom journalposten ble overlevert til Kelvin).
+     */
+    private fun håndterFeilregistrertJournalpost(record: JournalfoeringHendelseRecord) {
+        val journalpostId = JournalpostId(record.journalpostId)
+        log.info("Mottatt feilregistrert journalpost: $journalpostId")
+
+        transactionProvider.inTransaction {
+            val behandlinger = behandlingRepository.hentAlleBehandlingerForSak(journalpostId)
+            val åpenBehandling = behandlinger.find { it.status().erÅpen() }
+
+            when {
+                åpenBehandling != null -> {
+                    log.info("Fant åpen behandling for feilregistrert journalpost $journalpostId - trigger prosessering")
+                    triggProsesserBehandling(journalpostId, åpenBehandling)
+                }
+                behandlinger.isNotEmpty() -> {
+                    log.info("Alle behandlinger avsluttet for feilregistrert journalpost $journalpostId - oppretter jobb")
+                    flytJobbRepository.leggTil(
+                        JobbInput(FeilregistrertJournalpostJobbUtfører)
+                            .forSak(journalpostId.referanse)
+                            .medJournalpostId(journalpostId)
+                    )
+                }
+                else -> {
+                    log.info("Ingen behandlinger funnet for feilregistrert journalpost $journalpostId - ignorerer")
+                }
+            }
+        }
+    }
+
     private fun TransactionContext.triggProsesserBehandling(
         journalpostId: JournalpostId,
         behandling: Behandling,
@@ -169,10 +217,14 @@ object JoarkRegel {
     // Mulige verdier for tema: https://confluence.adeo.no/spaces/BOA/pages/316396024/Tema
     private const val TEMA_AAP = "AAP"
     private const val MOTTATT = "MOTTATT"
+    private const val FEILREGISTRERT = "FEILREGISTRERT"
     private const val EESSI = "EESSI"
 
     val harStatusMottatt: (String, JournalfoeringHendelseRecord) -> Boolean =
         { _, record -> record.journalpostStatus == MOTTATT }
+
+    val harStatusFeilregistrert: (String, JournalfoeringHendelseRecord) -> Boolean =
+        { _, record -> record.journalpostStatus == FEILREGISTRERT }
 
     /**
      * Mottakskanal er dokumentert [her](https://confluence.adeo.no/spaces/BOA/pages/316396050/Mottakskanal).

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/prosessering/FeilregistrertJournalpostJobbUtfører.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/prosessering/FeilregistrertJournalpostJobbUtfører.kt
@@ -1,0 +1,82 @@
+package no.nav.aap.postmottak.prosessering
+
+import no.nav.aap.komponenter.gateway.GatewayProvider
+import no.nav.aap.lookup.repository.RepositoryProvider
+import no.nav.aap.motor.JobbInput
+import no.nav.aap.motor.JobbUtfører
+import no.nav.aap.motor.ProvidersJobbSpesifikasjon
+import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.overlever.OverleveringVurderingRepository
+import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.sak.SaksnummerRepository
+import no.nav.aap.postmottak.gateway.BehandlingsflytGateway
+import no.nav.aap.postmottak.journalpostogbehandling.behandling.BehandlingRepository
+import no.nav.aap.postmottak.kontrakt.behandling.TypeBehandling
+import org.slf4j.LoggerFactory
+
+/**
+ * JobbUtfører som håndterer feilregistrerte journalposter der alle behandlinger er avsluttet.
+ *
+ * Dersom journalposten har blitt overlevert til Kelvin (skalOverleveresTilKelvin == true),
+ * sendes en feilregistrert-hendelse til behandlingsflyt.
+ */
+class FeilregistrertJournalpostJobbUtfører(
+    private val behandlingRepository: BehandlingRepository,
+    private val overleveringVurderingRepository: OverleveringVurderingRepository,
+    private val saksnummerRepository: SaksnummerRepository,
+    private val behandlingsflytGateway: BehandlingsflytGateway
+) : JobbUtfører {
+
+    private val log = LoggerFactory.getLogger(FeilregistrertJournalpostJobbUtfører::class.java)
+
+    companion object : ProvidersJobbSpesifikasjon {
+        override fun konstruer(repositoryProvider: RepositoryProvider, gatewayProvider: GatewayProvider): JobbUtfører {
+            return FeilregistrertJournalpostJobbUtfører(
+                repositoryProvider.provide(),
+                repositoryProvider.provide(),
+                repositoryProvider.provide(),
+                gatewayProvider.provide()
+            )
+        }
+
+        override val type = "feilregistrert.journalpost"
+
+        override val navn = "Håndter feilregistrert journalpost"
+
+        override val beskrivelse = "Sender feilregistrert-hendelse til behandlingsflyt dersom journalposten ble overlevert til Kelvin"
+    }
+
+    override fun utfør(input: JobbInput) {
+        val journalpostId = input.getJournalpostId()
+        log.info("Håndterer feilregistrert journalpost: $journalpostId")
+
+        val behandlinger = behandlingRepository.hentAlleBehandlingerForSak(journalpostId)
+        val dokumentflytBehandling = behandlinger.find {
+            it.typeBehandling == TypeBehandling.DokumentHåndtering
+        }
+
+        if (dokumentflytBehandling == null) {
+            log.info("Fant ingen dokumentflyt-behandling for journalpost $journalpostId - ingen hendelse sendes")
+            return
+        }
+
+        val overleveringVurdering = overleveringVurderingRepository.hentHvisEksisterer(dokumentflytBehandling.id)
+
+        if (overleveringVurdering?.skalOverleveresTilKelvin != true) {
+            log.info("Journalpost $journalpostId ble ikke overlevert til Kelvin - ingen hendelse sendes")
+            return
+        }
+
+        val saksnummer = saksnummerRepository.hentSakVurdering(dokumentflytBehandling.id)?.saksnummer
+
+        if (saksnummer == null) {
+            log.warn("Fant ikke saksnummer for behandling ${dokumentflytBehandling.id} - kan ikke sende feilregistrert-hendelse")
+            return
+        }
+
+        log.info("Sender feilregistrert-hendelse for journalpost $journalpostId til behandlingsflyt")
+        behandlingsflytGateway.sendFeilregistrertHendelse(
+            journalpostId = journalpostId,
+            saksnummer = saksnummer
+        )
+    }
+}
+

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/prosessering/ProsesseringsJobber.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/prosessering/ProsesseringsJobber.kt
@@ -18,6 +18,7 @@ object ProsesseringsJobber {
             GjenopptaBehandlingJobbUtfører,
             FordelingRegelJobbUtfører,
             FordelingVideresendJobbUtfører,
+            FeilregistrertJournalpostJobbUtfører,
             SendSøknadTilArenaJobbUtfører,
             ManuellJournalføringJobbUtfører,
             AutomatiskJournalføringJobbUtfører,

--- a/flyt/src/test/kotlin/no/nav/aap/postmottak/avklaringsbehov/løser/AvklaringsbehovsLøserTest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/postmottak/avklaringsbehov/løser/AvklaringsbehovsLøserTest.kt
@@ -4,10 +4,7 @@ import no.nav.aap.FakeUnleash
 import no.nav.aap.behandlingsflyt.kontrakt.hendelse.InnsendingType
 import no.nav.aap.behandlingsflyt.kontrakt.hendelse.dokumenter.Melding
 import no.nav.aap.behandlingsflyt.kontrakt.sak.Saksnummer
-import no.nav.aap.postmottak.test.MockConnection
 import no.nav.aap.komponenter.gateway.Factory
-import no.nav.aap.komponenter.repository.RepositoryRegistry
-import no.nav.aap.motor.FlytJobbRepositoryImpl
 import no.nav.aap.postmottak.gateway.BehandlingsflytGateway
 import no.nav.aap.postmottak.gateway.BehandlingsflytSak
 import no.nav.aap.postmottak.gateway.Klagebehandling
@@ -15,13 +12,8 @@ import no.nav.aap.postmottak.journalpostogbehandling.Ident
 import no.nav.aap.postmottak.journalpostogbehandling.behandling.dokumenter.KanalFraKodeverk
 import no.nav.aap.postmottak.klient.createGatewayProvider
 import no.nav.aap.postmottak.kontrakt.journalpost.JournalpostId
-import no.nav.aap.postmottak.repository.faktagrunnlag.AvklarTemaRepositoryImpl
-import no.nav.aap.postmottak.repository.faktagrunnlag.DigitaliseringsvurderingRepositoryImpl
-import no.nav.aap.postmottak.repository.faktagrunnlag.OverleveringVurderingRepositoryImpl
-import no.nav.aap.postmottak.repository.faktagrunnlag.SaksnummerRepositoryImpl
-import no.nav.aap.postmottak.repository.journalpost.JournalpostRepositoryImpl
 import no.nav.aap.postmottak.repository.postgresRepositoryRegistry
-import no.nav.aap.postmottak.test.Fakes
+import no.nav.aap.postmottak.test.MockConnection
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -92,6 +84,10 @@ class BehandlingsflytGatewayMock : BehandlingsflytGateway {
     }
 
     override fun finnKlagebehandlinger(saksnummer: Saksnummer): List<Klagebehandling> {
+        TODO("Not yet implemented")
+    }
+
+    override fun sendFeilregistrertHendelse(journalpostId: JournalpostId, saksnummer: String) {
         TODO("Not yet implemented")
     }
 }

--- a/flyt/src/test/kotlin/no/nav/aap/postmottak/flyt/Flyttest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/postmottak/flyt/Flyttest.kt
@@ -35,7 +35,6 @@ import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.sak.Saksinfo
 import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.sak.SaksnummerRepository
 import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.tema.AvklarTemaRepository
 import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.tema.Tema
-import no.nav.aap.postmottak.flyt.Flyttest.Companion.dataSource
 import no.nav.aap.postmottak.flyt.internals.TestHendelsesMottak
 import no.nav.aap.postmottak.gateway.Journalstatus
 import no.nav.aap.postmottak.hendelse.mottak.BehandlingSattPåVent
@@ -755,6 +754,48 @@ class Flyttest : WithDependencies {
         assertThat(redigitalisering).hasSize(2)
         assertThat(redigitalisering.last().status()).isEqualTo(Status.UTREDES)
         assertThat(redigitalisering.last().typeBehandling).isEqualTo(TypeBehandling.DokumentHåndtering)
+    }
+
+    @Test
+    fun `feilregistrert journalpost med åpen behandling trigger prosessering`() {
+        val journalpostId = TestJournalposter.PAPIR_SØKNAD
+        val behandlingId = opprettJournalføringsBehandling(journalpostId)
+
+        // Verifiser at behandlingen er åpen
+        var behandling = hentBehandling(behandlingId)
+        assertThat(behandling.status().erÅpen()).isTrue()
+
+        // Legg feilregistrert hendelse på Kafka
+        leggJournalpostPåKafka {
+            this.journalpostId = journalpostId.referanse
+            this.journalpostStatus = "FEILREGISTRERT"
+        }
+
+        // Vent på at behandlingen er prosessert
+        util.ventPåSvar(journalpostId.referanse, behandlingId.id)
+
+        // Behandlingen skal nå være avsluttet (stegene oppdager erUgyldig())
+        behandling = hentBehandling(behandlingId)
+        assertThat(behandling.status()).isEqualTo(Status.AVSLUTTET)
+    }
+
+    @Test
+    fun `feilregistrert journalpost uten behandlinger ignoreres`() {
+        val journalpostId = JournalpostId(9999L)
+
+        // Legg feilregistrert hendelse på Kafka for en journalpost uten behandlinger
+        val record = journalfoeringHendelseRecord().apply {
+            this.journalpostId = journalpostId.referanse
+            this.journalpostStatus = "FEILREGISTRERT"
+        }
+        val producerRecord = ProducerRecord(JOARK_TOPIC, "key", record)
+        producer.send(producerRecord)
+        producer.flush()
+        sleep(500)
+
+        // Verifiser at ingen behandlinger ble opprettet
+        val behandlinger = alleBehandlingerForJournalpost(journalpostId)
+        assertThat(behandlinger).isEmpty()
     }
 
     private fun <R> prøv(maksSekunder: Long = 10, block: () -> R): R? {

--- a/flyt/src/test/kotlin/no/nav/aap/postmottak/flyt/Flyttest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/postmottak/flyt/Flyttest.kt
@@ -758,7 +758,7 @@ class Flyttest : WithDependencies {
 
     @Test
     fun `feilregistrert journalpost med åpen behandling trigger prosessering`() {
-        val journalpostId = TestJournalposter.PAPIR_SØKNAD
+        val journalpostId = TestJournalposter.FEILREGISTRERT
         val behandlingId = opprettJournalføringsBehandling(journalpostId)
 
         // Verifiser at behandlingen er åpen

--- a/flyt/src/test/kotlin/no/nav/aap/postmottak/mottak/JoarkKafkaHandlerTest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/postmottak/mottak/JoarkKafkaHandlerTest.kt
@@ -15,7 +15,9 @@ import no.nav.aap.postmottak.klient.defaultGatewayProvider
 import no.nav.aap.postmottak.mottak.kafka.config.SchemaRegistryConfig
 import no.nav.aap.postmottak.mottak.kafka.config.SslConfig
 import no.nav.aap.postmottak.mottak.kafka.config.StreamsConfig
+import no.nav.aap.postmottak.prosessering.FeilregistrertJournalpostJobbUtfører
 import no.nav.aap.postmottak.prosessering.FordelingRegelJobbUtfører
+import no.nav.aap.postmottak.prosessering.ProsesserBehandlingJobbUtfører
 import no.nav.aap.postmottak.test.Fakes
 import no.nav.joarkjournalfoeringhendelser.JournalfoeringHendelseRecord
 import org.apache.kafka.common.serialization.Serdes
@@ -67,6 +69,88 @@ class JoarkKafkaHandlerTest {
             verify(exactly = 1) { flytJobbRepository.leggTil(any()) }
         }
 
+    }
+
+    @Test
+    fun `feilregistrert journalpost med åpen behandling trigger prosessering`() {
+        val config = config()
+        setUpStreamsMock(config) {
+            val hendelseRecord = lagHendelseRecord(jpStatus = "FEILREGISTRERT")
+
+            every { behandlingRepository.hentAlleBehandlingerForSak(any()) } returns listOf(mockk(relaxed = true) {
+                every { status() } returns mockk {
+                    every { erÅpen() } returns true
+                }
+                every { id } returns mockk {
+                    every { id } returns 1L
+                }
+            })
+
+            pipeInput("yolo", hendelseRecord)
+
+            Thread.sleep(100)
+
+            verify(exactly = 1) {
+                flytJobbRepository.leggTil(withArg {
+                    assertThat(it.type()).isEqualTo(ProsesserBehandlingJobbUtfører.type)
+                })
+            }
+        }
+    }
+
+    @Test
+    fun `feilregistrert journalpost med avsluttede behandlinger oppretter FeilregistrertJournalpostJobb`() {
+        val config = config()
+        setUpStreamsMock(config) {
+            val hendelseRecord = lagHendelseRecord(jpStatus = "FEILREGISTRERT")
+
+            every { behandlingRepository.hentAlleBehandlingerForSak(any()) } returns listOf(mockk(relaxed = true) {
+                every { status() } returns mockk {
+                    every { erÅpen() } returns false
+                }
+            })
+
+            pipeInput("yolo", hendelseRecord)
+
+            Thread.sleep(100)
+
+            verify(exactly = 1) {
+                flytJobbRepository.leggTil(withArg {
+                    assertThat(it.type()).isEqualTo(FeilregistrertJournalpostJobbUtfører.type)
+                })
+            }
+        }
+    }
+
+    @Test
+    fun `feilregistrert journalpost uten behandlinger oppretter ingen jobb`() {
+        val config = config()
+        setUpStreamsMock(config) {
+            val hendelseRecord = lagHendelseRecord(jpStatus = "FEILREGISTRERT")
+
+            every { behandlingRepository.hentAlleBehandlingerForSak(any()) } returns emptyList()
+
+            pipeInput("yolo", hendelseRecord)
+
+            Thread.sleep(100)
+
+            verify(exactly = 0) { flytJobbRepository.leggTil(any()) }
+        }
+    }
+
+    @Test
+    fun `feilregistrert journalpost med annet tema enn AAP ignoreres`() {
+        val config = config()
+        setUpStreamsMock(config) {
+            val hendelseRecord = lagHendelseRecord(jpStatus = "FEILREGISTRERT", nyttTema = "SYK")
+
+            pipeInput("yolo", hendelseRecord)
+
+            Thread.sleep(100)
+
+            verify(exactly = 0) { flytJobbRepository.leggTil(any()) }
+            verify(exactly = 0) { behandlingRepository.hentAlleBehandlingerForSak(any()) }
+        }
     }
 
     private fun setUpStreamsMock(

--- a/flyt/src/test/kotlin/no/nav/aap/postmottak/prosessering/FeilregistrertJournalpostJobbUtførerTest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/postmottak/prosessering/FeilregistrertJournalpostJobbUtførerTest.kt
@@ -1,0 +1,234 @@
+package no.nav.aap.postmottak.prosessering
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.aap.motor.JobbInput
+import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.overlever.OverleveringVurdering
+import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.overlever.OverleveringVurderingRepository
+import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.sak.SaksnummerRepository
+import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.sak.Saksvurdering
+import no.nav.aap.postmottak.gateway.BehandlingsflytGateway
+import no.nav.aap.postmottak.journalpostogbehandling.behandling.Behandling
+import no.nav.aap.postmottak.journalpostogbehandling.behandling.BehandlingId
+import no.nav.aap.postmottak.journalpostogbehandling.behandling.BehandlingRepository
+import no.nav.aap.postmottak.journalpostogbehandling.behandling.BehandlingsreferansePathParam
+import no.nav.aap.postmottak.kontrakt.behandling.Status
+import no.nav.aap.postmottak.kontrakt.behandling.TypeBehandling
+import no.nav.aap.postmottak.kontrakt.journalpost.JournalpostId
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.*
+
+internal class FeilregistrertJournalpostJobbUtførerTest {
+
+    private val behandlingRepository: BehandlingRepository = mockk(relaxed = true)
+    private val overleveringVurderingRepository: OverleveringVurderingRepository = mockk(relaxed = true)
+    private val saksnummerRepository: SaksnummerRepository = mockk(relaxed = true)
+    private val behandlingsflytGateway: BehandlingsflytGateway = mockk(relaxed = true)
+
+    private val feilregistrertJournalpostJobbUtfører = FeilregistrertJournalpostJobbUtfører(
+        behandlingRepository,
+        overleveringVurderingRepository,
+        saksnummerRepository,
+        behandlingsflytGateway
+    )
+
+    @Test
+    fun `sender feilregistrert-hendelse til behandlingsflyt når journalpost ble overlevert til Kelvin`() {
+        val journalpostId = JournalpostId(123L)
+        val behandlingId = BehandlingId(1L)
+        val saksnummer = "SAK123"
+
+        val dokumentflytBehandling = lagBehandling(
+            id = behandlingId,
+            journalpostId = journalpostId,
+            typeBehandling = TypeBehandling.DokumentHåndtering,
+            status = Status.AVSLUTTET
+        )
+
+        every { behandlingRepository.hentAlleBehandlingerForSak(journalpostId) } returns listOf(dokumentflytBehandling)
+        every { overleveringVurderingRepository.hentHvisEksisterer(behandlingId) } returns OverleveringVurdering(skalOverleveresTilKelvin = true)
+        every { saksnummerRepository.hentSakVurdering(behandlingId) } returns Saksvurdering(saksnummer = saksnummer)
+
+        feilregistrertJournalpostJobbUtfører.utfør(
+            JobbInput(FeilregistrertJournalpostJobbUtfører)
+                .forSak(journalpostId.referanse)
+                .medJournalpostId(journalpostId)
+        )
+
+        verify(exactly = 1) {
+            behandlingsflytGateway.sendFeilregistrertHendelse(
+                journalpostId = journalpostId,
+                saksnummer = saksnummer
+            )
+        }
+    }
+
+    @Test
+    fun `sender ikke hendelse når overleveringVurdering ikke finnes`() {
+        val journalpostId = JournalpostId(123L)
+        val behandlingId = BehandlingId(1L)
+
+        val dokumentflytBehandling = lagBehandling(
+            id = behandlingId,
+            journalpostId = journalpostId,
+            typeBehandling = TypeBehandling.DokumentHåndtering,
+            status = Status.AVSLUTTET
+        )
+
+        every { behandlingRepository.hentAlleBehandlingerForSak(journalpostId) } returns listOf(dokumentflytBehandling)
+        every { overleveringVurderingRepository.hentHvisEksisterer(behandlingId) } returns null
+
+        feilregistrertJournalpostJobbUtfører.utfør(
+            JobbInput(FeilregistrertJournalpostJobbUtfører)
+                .forSak(journalpostId.referanse)
+                .medJournalpostId(journalpostId)
+        )
+
+        verify(exactly = 0) {
+            behandlingsflytGateway.sendFeilregistrertHendelse(any(), any())
+        }
+    }
+
+    @Test
+    fun `sender ikke hendelse når skalOverleveresTilKelvin er false`() {
+        val journalpostId = JournalpostId(123L)
+        val behandlingId = BehandlingId(1L)
+
+        val dokumentflytBehandling = lagBehandling(
+            id = behandlingId,
+            journalpostId = journalpostId,
+            typeBehandling = TypeBehandling.DokumentHåndtering,
+            status = Status.AVSLUTTET
+        )
+
+        every { behandlingRepository.hentAlleBehandlingerForSak(journalpostId) } returns listOf(dokumentflytBehandling)
+        every { overleveringVurderingRepository.hentHvisEksisterer(behandlingId) } returns OverleveringVurdering(skalOverleveresTilKelvin = false)
+
+        feilregistrertJournalpostJobbUtfører.utfør(
+            JobbInput(FeilregistrertJournalpostJobbUtfører)
+                .forSak(journalpostId.referanse)
+                .medJournalpostId(journalpostId)
+        )
+
+        verify(exactly = 0) {
+            behandlingsflytGateway.sendFeilregistrertHendelse(any(), any())
+        }
+    }
+
+    @Test
+    fun `sender ikke hendelse når ingen dokumentflyt-behandling finnes`() {
+        val journalpostId = JournalpostId(123L)
+        val behandlingId = BehandlingId(1L)
+
+        val journalføringsbehandling = lagBehandling(
+            id = behandlingId,
+            journalpostId = journalpostId,
+            typeBehandling = TypeBehandling.Journalføring,
+            status = Status.AVSLUTTET
+        )
+
+        every { behandlingRepository.hentAlleBehandlingerForSak(journalpostId) } returns listOf(journalføringsbehandling)
+
+        feilregistrertJournalpostJobbUtfører.utfør(
+            JobbInput(FeilregistrertJournalpostJobbUtfører)
+                .forSak(journalpostId.referanse)
+                .medJournalpostId(journalpostId)
+        )
+
+        verify(exactly = 0) {
+            behandlingsflytGateway.sendFeilregistrertHendelse(any(), any())
+        }
+    }
+
+    @Test
+    fun `sender ikke hendelse når saksnummer ikke finnes`() {
+        val journalpostId = JournalpostId(123L)
+        val behandlingId = BehandlingId(1L)
+
+        val dokumentflytBehandling = lagBehandling(
+            id = behandlingId,
+            journalpostId = journalpostId,
+            typeBehandling = TypeBehandling.DokumentHåndtering,
+            status = Status.AVSLUTTET
+        )
+
+        every { behandlingRepository.hentAlleBehandlingerForSak(journalpostId) } returns listOf(dokumentflytBehandling)
+        every { overleveringVurderingRepository.hentHvisEksisterer(behandlingId) } returns OverleveringVurdering(skalOverleveresTilKelvin = true)
+        every { saksnummerRepository.hentSakVurdering(behandlingId) } returns null
+
+        feilregistrertJournalpostJobbUtfører.utfør(
+            JobbInput(FeilregistrertJournalpostJobbUtfører)
+                .forSak(journalpostId.referanse)
+                .medJournalpostId(journalpostId)
+        )
+
+        verify(exactly = 0) {
+            behandlingsflytGateway.sendFeilregistrertHendelse(any(), any())
+        }
+    }
+
+    @Test
+    fun `finner riktig dokumentflyt-behandling når det finnes både journalføring og dokumenthåndtering`() {
+        val journalpostId = JournalpostId(123L)
+        val journalføringsBehandlingId = BehandlingId(1L)
+        val dokumentflytBehandlingId = BehandlingId(2L)
+        val saksnummer = "SAK456"
+
+        val journalføringsbehandling = lagBehandling(
+            id = journalføringsBehandlingId,
+            journalpostId = journalpostId,
+            typeBehandling = TypeBehandling.Journalføring,
+            status = Status.AVSLUTTET
+        )
+
+        val dokumentflytBehandling = lagBehandling(
+            id = dokumentflytBehandlingId,
+            journalpostId = journalpostId,
+            typeBehandling = TypeBehandling.DokumentHåndtering,
+            status = Status.AVSLUTTET
+        )
+
+        every { behandlingRepository.hentAlleBehandlingerForSak(journalpostId) } returns listOf(journalføringsbehandling, dokumentflytBehandling)
+        every { overleveringVurderingRepository.hentHvisEksisterer(dokumentflytBehandlingId) } returns OverleveringVurdering(skalOverleveresTilKelvin = true)
+        every { saksnummerRepository.hentSakVurdering(dokumentflytBehandlingId) } returns Saksvurdering(saksnummer = saksnummer)
+
+        feilregistrertJournalpostJobbUtfører.utfør(
+            JobbInput(FeilregistrertJournalpostJobbUtfører)
+                .forSak(journalpostId.referanse)
+                .medJournalpostId(journalpostId)
+        )
+
+        verify(exactly = 1) {
+            behandlingsflytGateway.sendFeilregistrertHendelse(
+                journalpostId = journalpostId,
+                saksnummer = saksnummer
+            )
+        }
+
+        // Verifiser at vi ikke sjekket journalføringsbehandlingen
+        verify(exactly = 0) {
+            overleveringVurderingRepository.hentHvisEksisterer(journalføringsBehandlingId)
+        }
+    }
+
+    private fun lagBehandling(
+        id: BehandlingId,
+        journalpostId: JournalpostId,
+        typeBehandling: TypeBehandling,
+        status: Status
+    ): Behandling {
+        return Behandling(
+            id = id,
+            journalpostId = journalpostId,
+            status = status,
+            opprettetTidspunkt = LocalDateTime.now(),
+            referanse = BehandlingsreferansePathParam(UUID.randomUUID()),
+            typeBehandling = typeBehandling
+        )
+    }
+}
+
+
+

--- a/klienter/src/main/kotlin/no/nav/aap/postmottak/klient/behandlingsflyt/BehandlingsflytKlient.kt
+++ b/klienter/src/main/kotlin/no/nav/aap/postmottak/klient/behandlingsflyt/BehandlingsflytKlient.kt
@@ -119,6 +119,33 @@ class BehandlingsflytKlient : BehandlingsflytGateway {
         return client.post<BehandlingsflytTypeBehandling, List<Klagebehandling>>(url, request) ?: emptyList()
     }
 
+    override fun sendFeilregistrertHendelse(
+        journalpostId: JournalpostId,
+        saksnummer: String,
+    ) {
+        log.info("Sender feilregistrert-hendelse for journalpost $journalpostId til sak $saksnummer")
+        val url = url.resolve("/api/hendelse/send")
+        val request = PostRequest(
+            Innsending(
+                Saksnummer(saksnummer),
+                InnsendingReferanse(
+                    InnsendingReferanse.Type.JOURNALPOST,
+                    journalpostId.referanse.toString()
+                ),
+                // TODO: Bytt til InnsendingType.FEILREGISTRERT_JOURNALPOST når den er tilgjengelig i behandlingsflyt:kontrakt
+                InnsendingType.ANNET_RELEVANT_DOKUMENT,
+                Kanal.DIGITAL,
+                LocalDateTime.now(),
+                null,
+                false
+            ),
+            additionalHeaders = listOf(
+                Header("Accept", "application/json")
+            )
+        )
+        client.post<Innsending, Unit>(url, request)
+    }
+
 }
 
 fun KanalFraKodeverk.tilBehandlingsflytKanal(): Kanal {

--- a/lib-test/src/main/kotlin/no/nav/aap/postmottak/test/fakes/FakeKonstanter.kt
+++ b/lib-test/src/main/kotlin/no/nav/aap/postmottak/test/fakes/FakeKonstanter.kt
@@ -18,6 +18,7 @@ object TestJournalposter {
     val MED_GOSYS_OPPGAVER = JournalpostId(128)
     val PERSON_MED_SAK_I_ARENA = JournalpostId(129)
     val LEGEERKLÆRING_TRUKKET_SAK = JournalpostId(130)
+    val FEILREGISTRERT = JournalpostId(131)
 }
 
 

--- a/lib-test/src/main/kotlin/no/nav/aap/postmottak/test/fakes/Saf.kt
+++ b/lib-test/src/main/kotlin/no/nav/aap/postmottak/test/fakes/Saf.kt
@@ -235,6 +235,7 @@ private fun ingenSakerRespons() =
 private fun finnStatus(journalpostId: Long) =
     when (journalpostId) {
         TestJournalposter.UGYLDIG_STATUS.referanse -> "UTGAAR"
+        TestJournalposter.FEILREGISTRERT.referanse -> "FEILREGISTRERT"
         TestJournalposter.STATUS_JOURNALFØRT.referanse, TestJournalposter.STATUS_JOURNALFØRT_ANNET_FAGSYSTEM.referanse -> "JOURNALFOERT"
         else -> "MOTTATT"
     }


### PR DESCRIPTION
Når vi mottar en feilregistrert journalpost:
- Hvis det finnes en åpen behandling: trigger prosessering slik at stegene kan oppdage at journalposten er feilregistrert (via erUgyldig()) og avslutte behandlingen
- Hvis alle behandlinger er avsluttet: opprett jobb som sender feilregistrert-hendelse til behandlingsflyt (kun hvis journalposten ble overlevert til Kelvin)
- Hvis ingen behandlinger finnes: ignorer hendelsen

Endringer:
- Ny FeilregistrertJournalpostJobbUtfører som sjekker overleveringVurdering og sender hendelse til behandlingsflyt med InnsendingType.ANNET_RELEVANT_DOKUMENT (midlertidig - skal erstattes med FEILREGISTRERT_JOURNALPOST når tilgjengelig)
- Utvidet KafkaStreams.kt til å lytte på både MOTTATT og FEILREGISTRERT-status
- Ny håndterFeilregistrertJournalpost-metode i JoarkKafkaHandler
- Ny sendFeilregistrertHendelse metode i BehandlingsflytGateway og BehandlingsflytKlient
- Enhetstester (6 tester) og integrasjonstester (2 tester)
- Oppdatert test-fakes til å støtte FEILREGISTRERT-status

TODO: 
- Fjern litt kommentarer
- Oppdater kontrakt i behandlingsflyt
- Håndtering i behandlingsflyt