### PR TITLE
Legg ved sporing på hvem som oppdaterer journalpost

### DIFF
--- a/flyt/src/main/kotlin/no/nav/aap/fordeler/arena/ArenaVideresender.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/fordeler/arena/ArenaVideresender.kt
@@ -58,8 +58,8 @@ class ArenaVideresender(
 
         when (journalpost.hoveddokumentbrevkode) {
             Brevkoder.LEGEERKLÆRING.kode -> {
-                joarkClient.førJournalpostPåGenerellSak(journalpost, ARENA_LEGEERKLÆRING_TEMA)
-                joarkClient.ferdigstillJournalpostMaskinelt(journalpost.journalpostId)
+                joarkClient.førJournalpostPåGenerellSak(journalpost, ARENA_LEGEERKLÆRING_TEMA, endretAv = null)
+                joarkClient.ferdigstillJournalpostMaskinelt(journalpost.journalpostId, journalførtAv = null)
             }
 
             Brevkoder.SØKNAD.kode -> sendSøknadTilArena(journalpost, innkommendeJournalpostId)

--- a/flyt/src/main/kotlin/no/nav/aap/fordeler/arena/jobber/AutomatiskJournalføringJobbUtfører.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/fordeler/arena/jobber/AutomatiskJournalføringJobbUtfører.kt
@@ -70,9 +70,10 @@ class AutomatiskJournalføringJobbUtfører(
             journalpost.journalpostId,
             kontekst.ident,
             kontekst.saksnummer,
-            fagsystem = Fagsystem.AO01
+            fagsystem = Fagsystem.AO01,
+            endretAv = null,
         )
-        joarkClient.ferdigstillJournalpostMaskinelt(kontekst.journalpostId)
+        joarkClient.ferdigstillJournalpostMaskinelt(kontekst.journalpostId, journalførtAv = null)
 
         gosysOppgaveGateway.finnOppgaverForJournalpost(journalpost.journalpostId, tema = "AAP")
             .forEach { gosysOppgaveGateway.ferdigstillOppgave(it) }

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/avklaringsbehov/Avklaringsbehovene.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/avklaringsbehov/Avklaringsbehovene.kt
@@ -113,6 +113,14 @@ class Avklaringsbehovene(
         return alle().singleOrNull { it.definisjon == definisjon }
     }
 
+    fun hvemSomLøste(definisjon: Definisjon): Bruker? {
+        return hentBehovForDefinisjon(definisjon)
+            ?.historikk
+            ?.lastOrNull { it.status == no.nav.aap.postmottak.kontrakt.avklaringsbehov.Status.AVSLUTTET }
+            ?.endretAv
+            ?.let(::Bruker)
+    }
+
     internal fun internalAvbryt(definisjon: Definisjon) {
         val avklaringsbehov = alle().single { it.definisjon == definisjon }
         avklaringsbehov.avbryt()

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/forretningsflyt/steg/journalføring/JournalføringSteg.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/forretningsflyt/steg/journalføring/JournalføringSteg.kt
@@ -2,6 +2,7 @@ package no.nav.aap.postmottak.forretningsflyt.steg.journalføring
 
 import no.nav.aap.komponenter.gateway.GatewayProvider
 import no.nav.aap.lookup.repository.RepositoryProvider
+import no.nav.aap.postmottak.avklaringsbehov.AvklaringsbehovRepository
 import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.JournalpostRepository
 import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.tema.AvklarTemaRepository
 import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.tema.Tema
@@ -12,22 +13,25 @@ import no.nav.aap.postmottak.flyt.steg.StegResultat
 import no.nav.aap.postmottak.gateway.JournalføringService
 import no.nav.aap.postmottak.gateway.Journalstatus
 import no.nav.aap.postmottak.journalpostogbehandling.flyt.FlytKontekst
+import no.nav.aap.postmottak.kontrakt.avklaringsbehov.Definisjon
 import no.nav.aap.postmottak.kontrakt.steg.StegType
 
 class JournalføringSteg(
     private val journalpostRepository: JournalpostRepository,
     private val joarkKlient: JournalføringService,
-    private val avklarTemaRepository: AvklarTemaRepository
+    private val avklarTemaRepository: AvklarTemaRepository,
+    private val avklaringsbehovRepository: AvklaringsbehovRepository,
 ) : BehandlingSteg {
     companion object : FlytSteg {
         override fun konstruer(
             repositoryProvider: RepositoryProvider,
-            gatewayProvider: GatewayProvider
+            gatewayProvider: GatewayProvider,
         ): BehandlingSteg {
             return JournalføringSteg(
                 repositoryProvider.provide(),
                 JournalføringService(gatewayProvider),
-                repositoryProvider.provide()
+                repositoryProvider.provide(),
+                repositoryProvider.provide(),
             )
         }
 
@@ -48,7 +52,10 @@ class JournalføringSteg(
             return Fullført
         }
 
-        joarkKlient.ferdigstillJournalpostMaskinelt(journalpost.journalpostId)
+        val journalførtAv = avklaringsbehovRepository.hentAvklaringsbehovene(kontekst.behandlingId)
+            .hvemSomLøste(Definisjon.AVKLAR_SAK)
+
+        joarkKlient.ferdigstillJournalpostMaskinelt(journalpost.journalpostId, journalførtAv = journalførtAv)
 
         return Fullført
     }

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/forretningsflyt/steg/journalføring/SettFagsakSteg.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/forretningsflyt/steg/journalføring/SettFagsakSteg.kt
@@ -1,7 +1,10 @@
 package no.nav.aap.postmottak.forretningsflyt.steg.journalføring
 
+import no.nav.aap.api.intern.Status
 import no.nav.aap.komponenter.gateway.GatewayProvider
+import no.nav.aap.komponenter.verdityper.Bruker
 import no.nav.aap.lookup.repository.RepositoryProvider
+import no.nav.aap.postmottak.avklaringsbehov.AvklaringsbehovRepository
 import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.JournalpostRepository
 import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.sak.SaksnummerRepository
 import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.tema.AvklarTemaRepository
@@ -13,13 +16,15 @@ import no.nav.aap.postmottak.flyt.steg.StegResultat
 import no.nav.aap.postmottak.gateway.JournalføringService
 import no.nav.aap.postmottak.gateway.Journalstatus
 import no.nav.aap.postmottak.journalpostogbehandling.flyt.FlytKontekst
+import no.nav.aap.postmottak.kontrakt.avklaringsbehov.Definisjon
 import no.nav.aap.postmottak.kontrakt.steg.StegType
 
 class SettFagsakSteg(
     private val journalpostRepository: JournalpostRepository,
     private val saksnummerRepository: SaksnummerRepository,
     private val avklarTemaRepository: AvklarTemaRepository,
-    private val journalføringService: JournalføringService
+    private val journalføringService: JournalføringService,
+    private val avklaringsbehovRepository: AvklaringsbehovRepository,
 ) : BehandlingSteg {
     companion object : FlytSteg {
         override fun konstruer(
@@ -30,7 +35,8 @@ class SettFagsakSteg(
                 repositoryProvider.provide(),
                 repositoryProvider.provide(),
                 repositoryProvider.provide(),
-                JournalføringService(gatewayProvider)
+                JournalføringService(gatewayProvider),
+                repositoryProvider.provide(),
             )
         }
 
@@ -56,13 +62,18 @@ class SettFagsakSteg(
 
         val avsenderMottaker = saksvurdering.avsenderMottaker?.takeUnless { journalpost.kanal.erDigitalKanal() }
 
+        val endretAv = avklaringsbehovRepository.hentAvklaringsbehovene(kontekst.behandlingId)
+            .hvemSomLøste(Definisjon.AVKLAR_SAK)
+
+
         if (saksvurdering.generellSak) {
             journalføringService.førJournalpostPåGenerellSak(
                 journalpost = journalpost,
                 tema = temaavklaring.tema.name,
                 tittel = saksvurdering.journalposttittel,
                 avsenderMottaker = avsenderMottaker,
-                dokumenter = saksvurdering.dokumenter
+                dokumenter = saksvurdering.dokumenter,
+                endretAv = endretAv,
             )
         } else {
             journalføringService.førJournalpostPåFagsak(
@@ -71,7 +82,8 @@ class SettFagsakSteg(
                 fagsakId = saksvurdering.saksnummer!!,
                 tittel = saksvurdering.journalposttittel,
                 avsenderMottaker = avsenderMottaker,
-                dokumenter = saksvurdering.dokumenter
+                dokumenter = saksvurdering.dokumenter,
+                endretAv = endretAv,
             )
         }
 

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/gateway/JournalføringService.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/gateway/JournalføringService.kt
@@ -6,11 +6,13 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import no.nav.aap.komponenter.config.requiredConfigForKey
 import no.nav.aap.komponenter.gateway.GatewayProvider
 import no.nav.aap.komponenter.httpklient.httpclient.ClientConfig
+import no.nav.aap.komponenter.httpklient.httpclient.Header
 import no.nav.aap.komponenter.httpklient.httpclient.RestClient
 import no.nav.aap.komponenter.httpklient.httpclient.put
 import no.nav.aap.komponenter.httpklient.httpclient.request.PatchRequest
 import no.nav.aap.komponenter.httpklient.httpclient.request.PutRequest
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.azurecc.ClientCredentialsTokenProvider
+import no.nav.aap.komponenter.verdityper.Bruker
 import no.nav.aap.postmottak.JournalføringsType
 import no.nav.aap.postmottak.PrometheusProvider
 import no.nav.aap.postmottak.avklaringsbehov.løsning.ForenkletDokument
@@ -18,6 +20,8 @@ import no.nav.aap.postmottak.journalføringCounter
 import no.nav.aap.postmottak.journalpostogbehandling.Ident
 import no.nav.aap.postmottak.journalpostogbehandling.journalpost.Journalpost
 import no.nav.aap.postmottak.kontrakt.journalpost.JournalpostId
+import no.nav.aap.unleash.PostmottakFeature
+import no.nav.aap.unleash.UnleashGateway
 import java.io.InputStream
 import java.net.URI
 
@@ -26,7 +30,8 @@ private const val MASKINELL_JOURNALFØRING_ENHET = "9999"
 class JournalføringService(
     private val client: RestClient<InputStream>,
     private val safGraphqlKlient: JournalpostGateway,
-    val prometheus: MeterRegistry = SimpleMeterRegistry()
+    val prometheus: MeterRegistry = SimpleMeterRegistry(),
+    private val unleashGateway: UnleashGateway,
 ) {
 
     private val url = URI.create(requiredConfigForKey("integrasjon.joark.url"))
@@ -35,9 +40,10 @@ class JournalføringService(
         fun konstruer(
             restClient: RestClient<InputStream>,
             safGraphqlKlient: JournalpostGateway,
-            prometheus: MeterRegistry = SimpleMeterRegistry()
+            prometheus: MeterRegistry = SimpleMeterRegistry(),
+            unleashGateway: UnleashGateway,
         ): JournalføringService {
-            return JournalføringService(restClient, safGraphqlKlient, prometheus)
+            return JournalføringService(restClient, safGraphqlKlient, prometheus, unleashGateway)
         }
     }
 
@@ -49,8 +55,9 @@ class JournalføringService(
                 scope = requiredConfigForKey("integrasjon.joark.scope"),
             ),
             tokenProvider = ClientCredentialsTokenProvider,
-            prometheus = PrometheusProvider.prometheus
-        )
+            prometheus = PrometheusProvider.prometheus,
+        ),
+        unleashGateway = gatewayProvider.provide<UnleashGateway>(),
     )
 
     fun førJournalpostPåFagsak(
@@ -62,10 +69,11 @@ class JournalføringService(
         tittel: String? = null,
         avsenderMottaker: AvsenderMottakerDto? = null,
         dokumenter: List<ForenkletDokument>? = null,
+        endretAv: Bruker?,
     ) {
         val path = url.resolve("/rest/journalpostapi/v1/journalpost/${journalpostId}")
         val request = PutRequest(
-            OppdaterJournalpostRequest(
+            body = OppdaterJournalpostRequest(
                 sak = JournalpostSak(
                     fagsakId = fagsakId,
                     fagsaksystem = fagsystem,
@@ -79,7 +87,8 @@ class JournalføringService(
                     journalpostId
                 ),
                 dokumenter = dokumenter
-            )
+            ),
+            additionalHeaders = navUserIdHeader(endretAv),
         )
         client.put<OppdaterJournalpostRequest, Unit>(path, request)
     }
@@ -89,11 +98,12 @@ class JournalføringService(
         tema: String = "AAP",
         tittel: String? = null,
         avsenderMottaker: AvsenderMottakerDto? = null,
-        dokumenter: List<ForenkletDokument>? = null
+        dokumenter: List<ForenkletDokument>? = null,
+        endretAv: Bruker?,
     ) {
         val path = url.resolve("/rest/journalpostapi/v1/journalpost/${journalpost.journalpostId}")
         val request = PutRequest(
-            OppdaterJournalpostRequest(
+            body = OppdaterJournalpostRequest(
                 sak = JournalpostSak(
                     sakstype = Sakstype.GENERELL_SAK,
                     fagsaksystem = null
@@ -107,21 +117,42 @@ class JournalføringService(
                     journalpost.journalpostId
                 ),
                 dokumenter = dokumenter
-            )
+            ),
+            additionalHeaders = navUserIdHeader(endretAv),
         )
         client.put(path, request) { _, _ -> }
     }
 
-    fun ferdigstillJournalpostMaskinelt(journalpostId: JournalpostId) {
-        ferdigstillJournalpost(journalpostId, MASKINELL_JOURNALFØRING_ENHET)
+    fun ferdigstillJournalpostMaskinelt(
+        journalpostId: JournalpostId,
+        journalførtAv: Bruker?,
+    ) {
+        ferdigstillJournalpost(journalpostId, MASKINELL_JOURNALFØRING_ENHET, journalførtAv)
     }
 
-    fun ferdigstillJournalpost(journalpostId: JournalpostId, journalfoerendeEnhet: String) {
+    fun ferdigstillJournalpost(
+        journalpostId: JournalpostId,
+        journalfoerendeEnhet: String,
+        journalførtAv: Bruker?,
+    ) {
         val path = url.resolve("/rest/journalpostapi/v1/journalpost/$journalpostId/ferdigstill")
-        val request = PatchRequest(FerdigstillRequest(journalfoerendeEnhet))
+        val request = PatchRequest(
+            body = FerdigstillRequest(journalfoerendeEnhet),
+            additionalHeaders = navUserIdHeader(journalførtAv),
+        )
         client.patch(path, request) { _, _ -> }
         prometheus.journalføringCounter(type = JournalføringsType.automatisk).increment()
     }
+
+    private fun navUserIdHeader(endretAv: Bruker?): List<Header> =
+        if (unleashGateway.isEnabled(PostmottakFeature.SporingSaksbehandlerJournalforing))
+            listOfNotNull(
+                endretAv?.let {
+                    Header("Nav-User-Id", it.ident)
+                }
+            )
+        else
+            emptyList()
 
     private fun hentAvsenderMottakerOmNødvendig(journalpostId: JournalpostId): AvsenderMottakerDto? {
         val safJournalpost = safGraphqlKlient.hentJournalpost(journalpostId)

--- a/flyt/src/main/kotlin/no/nav/aap/unleash/FeatureToggle.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/unleash/FeatureToggle.kt
@@ -8,6 +8,7 @@ enum class PostmottakFeature : FeatureToggle {
     // Eksempel på feature toggle. Kan fjernes når det legges til nye.
     // Se: https://aap-unleash-web.iap.nav.cloud.nais.io/projects/default
     DummyFeature,
+    SporingSaksbehandlerJournalforing,
     ;
 
     override fun key(): String = name

--- a/flyt/src/test/kotlin/no/nav/aap/FakeUnleash.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/FakeUnleash.kt
@@ -11,7 +11,7 @@ object FakeUnleash : UnleashGateway {
 
         return when (featureToggle) {
             PostmottakFeature.DummyFeature -> TODO()
-            else -> TODO()
+            PostmottakFeature.SporingSaksbehandlerJournalforing -> true
         }
     }
 

--- a/flyt/src/test/kotlin/no/nav/aap/fordeler/arena/ArenaVideresenderTest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/fordeler/arena/ArenaVideresenderTest.kt
@@ -58,8 +58,8 @@ class ArenaVideresenderTest {
             journalpostId_, innkommendeJournalpostId = 1L,
         )
 
-        verify(exactly = 1) { joarkClient.førJournalpostPåGenerellSak(journalpost, "OPP", null, null, null) }
-        verify(exactly = 1) { joarkClient.ferdigstillJournalpostMaskinelt(journalpostId_) }
+        verify(exactly = 1) { joarkClient.førJournalpostPåGenerellSak(journalpost, "OPP", null, null, null, null) }
+        verify(exactly = 1) { joarkClient.ferdigstillJournalpostMaskinelt(journalpostId_, null) }
 
     }
 

--- a/flyt/src/test/kotlin/no/nav/aap/postmottak/forretningsflyt/steg/journalføring/JournalføringStegTest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/postmottak/forretningsflyt/steg/journalføring/JournalføringStegTest.kt
@@ -3,6 +3,7 @@ package no.nav.aap.postmottak.forretningsflyt.steg.journalføring
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.aap.postmottak.avklaringsbehov.AvklaringsbehovRepository
 import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.JournalpostRepository
 import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.sak.SaksnummerRepository
 import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.tema.AvklarTemaRepository
@@ -12,6 +13,7 @@ import no.nav.aap.postmottak.flyt.steg.Fullført
 import no.nav.aap.postmottak.gateway.JournalføringService
 import no.nav.aap.postmottak.journalpostogbehandling.behandling.BehandlingId
 import no.nav.aap.postmottak.journalpostogbehandling.journalpost.Journalpost
+import no.nav.aap.postmottak.kontrakt.avklaringsbehov.Definisjon
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -21,9 +23,10 @@ class JournalføringStegTest {
     val journalpostRepository: JournalpostRepository = mockk()
     val joark: JournalføringService = mockk(relaxed = true)
     val avklarTemaRepository: AvklarTemaRepository = mockk(relaxed = true)
+    val avklaringsbehovRepository: AvklaringsbehovRepository = mockk(relaxed = true)
 
     val journalføringSteg = JournalføringSteg(
-        journalpostRepository, joark, avklarTemaRepository
+        journalpostRepository, joark, avklarTemaRepository, avklaringsbehovRepository
     )
 
     @Test
@@ -34,10 +37,11 @@ class JournalføringStegTest {
 
         val saksnummer = "saksnummer"
         every { saksnummerRepository.hentSakVurdering(any())?.saksnummer } returns saksnummer
+        every { avklaringsbehovRepository.hentAvklaringsbehovene(any()).hvemSomLøste(Definisjon.AVKLAR_SAK) } returns null
 
         journalføringSteg.utfør(mockk(relaxed = true))
 
-        verify(exactly = 1) { joark.ferdigstillJournalpostMaskinelt(journalpost.journalpostId) }
+        verify(exactly = 1) { joark.ferdigstillJournalpostMaskinelt(journalpost.journalpostId, null) }
     }
 
     @Test

--- a/flyt/src/test/kotlin/no/nav/aap/postmottak/forretningsflyt/steg/journalføring/SettFagsakStegTest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/postmottak/forretningsflyt/steg/journalføring/SettFagsakStegTest.kt
@@ -3,6 +3,7 @@ package no.nav.aap.postmottak.forretningsflyt.steg.journalføring
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.aap.postmottak.avklaringsbehov.AvklaringsbehovRepository
 import no.nav.aap.postmottak.avklaringsbehov.løsning.ForenkletDokument
 import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.JournalpostRepository
 import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.sak.SaksnummerRepository
@@ -16,6 +17,7 @@ import no.nav.aap.postmottak.gateway.JournalføringService
 import no.nav.aap.postmottak.journalpostogbehandling.behandling.BehandlingId
 import no.nav.aap.postmottak.journalpostogbehandling.behandling.dokumenter.KanalFraKodeverk
 import no.nav.aap.postmottak.journalpostogbehandling.journalpost.Journalpost
+import no.nav.aap.postmottak.kontrakt.avklaringsbehov.Definisjon
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -25,14 +27,16 @@ class SettFagsakStegTest {
     val journalpostRepository: JournalpostRepository = mockk()
     val avklarTemaRepository: AvklarTemaRepository = mockk()
     val joark: JournalføringService = mockk(relaxed = true)
+    val avklaringsbehovRepository: AvklaringsbehovRepository = mockk(relaxed = true)
 
-    val settFagsakSteg = SettFagsakSteg(journalpostRepository, saksnummerRepository, avklarTemaRepository, joark)
+    val settFagsakSteg = SettFagsakSteg(journalpostRepository, saksnummerRepository, avklarTemaRepository, joark, avklaringsbehovRepository)
 
     @Test
     fun `verifiser at journalpost blir oppdatert med saksnummer`() {
         val journalpost: Journalpost = mockk(relaxed = true)
         every { avklarTemaRepository.hentTemaAvklaring(any()) } returns TemaVurdering(true, Tema.AAP)
         every { journalpostRepository.hentHvisEksisterer(any<BehandlingId>()) } returns journalpost
+        every { avklaringsbehovRepository.hentAvklaringsbehovene(any()).hvemSomLøste(Definisjon.AVKLAR_SAK) } returns null
 
         val vurdering = Saksvurdering(
             "12345",
@@ -52,7 +56,8 @@ class SettFagsakStegTest {
                 vurdering.saksnummer!!,
                 tittel = vurdering.journalposttittel,
                 avsenderMottaker = vurdering.avsenderMottaker,
-                dokumenter = vurdering.dokumenter
+                dokumenter = vurdering.dokumenter,
+                endretAv = null,
             )
         }
     }
@@ -64,6 +69,7 @@ class SettFagsakStegTest {
         }
         every { avklarTemaRepository.hentTemaAvklaring(any()) } returns TemaVurdering(true, Tema.AAP)
         every { journalpostRepository.hentHvisEksisterer(any<BehandlingId>()) } returns journalpost
+        every { avklaringsbehovRepository.hentAvklaringsbehovene(any()).hvemSomLøste(Definisjon.AVKLAR_SAK) } returns null
 
         val vurdering = Saksvurdering(
             "12345",
@@ -83,7 +89,8 @@ class SettFagsakStegTest {
                 vurdering.saksnummer!!,
                 tittel = vurdering.journalposttittel,
                 avsenderMottaker = null,
-                dokumenter = vurdering.dokumenter
+                dokumenter = vurdering.dokumenter,
+                endretAv = null,
             )
         }
     }

--- a/flyt/src/test/kotlin/no/nav/aap/postmottak/joark/JoarkClientTest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/postmottak/joark/JoarkClientTest.kt
@@ -5,6 +5,7 @@ import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.aap.FakeUnleash
 import no.nav.aap.komponenter.gateway.GatewayProvider
 import no.nav.aap.komponenter.gateway.GatewayRegistry
 import no.nav.aap.komponenter.httpklient.httpclient.RestClient
@@ -33,6 +34,7 @@ class JoarkClientTest {
     private val gatewayRegistry = GatewayRegistry()
         .register<SafGraphqlClientCredentialsClient>()
         .register<PdlGraphqlKlient>()
+        .register<FakeUnleash>()
 
     private val gatewayProvider = GatewayProvider(gatewayRegistry)
 
@@ -58,7 +60,8 @@ class JoarkClientTest {
             "213412",
             tittel = null,
             avsenderMottaker = null,
-            dokumenter = null
+            dokumenter = null,
+            endretAv = null,
         )
     }
 
@@ -73,7 +76,7 @@ class JoarkClientTest {
         )
         every { journalpost.journalpostId } returns JournalpostId(1)
 
-        joarkClient.førJournalpostPåGenerellSak(journalpost, tittel = null, avsenderMottaker = null, dokumenter = null)
+        joarkClient.førJournalpostPåGenerellSak(journalpost, tittel = null, avsenderMottaker = null, dokumenter = null, endretAv = null)
     }
 
     @Test
@@ -87,7 +90,7 @@ class JoarkClientTest {
         )
         every { journalpost.journalpostId } returns JournalpostId(1)
 
-        joarkClient.ferdigstillJournalpostMaskinelt(journalpost.journalpostId)
+        joarkClient.ferdigstillJournalpostMaskinelt(journalpost.journalpostId, null)
     }
 
     @Test
@@ -95,7 +98,7 @@ class JoarkClientTest {
 
         val restClient = mockk<RestClient<InputStream>>(relaxed = true)
         val joarkClient =
-            JournalføringService.konstruer(restClient, SafGraphqlClientCredentialsClient())
+            JournalføringService.konstruer(restClient, SafGraphqlClientCredentialsClient(), unleashGateway = FakeUnleash)
 
         val safJournalpost = SafGraphqlClientCredentialsClient().hentJournalpost(TestJournalposter.UTEN_AVSENDER_MOTTAKER)
 
@@ -107,7 +110,8 @@ class JoarkClientTest {
             "2344",
             tittel = null,
             avsenderMottaker = null,
-            dokumenter = null
+            dokumenter = null,
+            endretAv = null,
         )
 
         verify {


### PR DESCRIPTION
**Dagens kode:**
Vi bruker maskin-token, og dokarkiv vil derfor automatisk legge på appen sitt navn i sporingsloggen i journalposten.

**Denne PRen innfører:**
Når vi faller ut til manuell journalføring, så sender vi med ident til personen som endret eller ferdigstilte journalposten, slik at det kommer med i sporingsloggen til journalposten.

Brude nok også sette journalførende enhet ved manuell journalføring, men holder det utenfor denne PRen.

Se også https://nav-it.slack.com/archives/C6W9E5GPJ/p1643268523091400