### PR TITLE
Prometheus forbedringer

### DIFF
--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/PrometheusProvider.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/PrometheusProvider.kt
@@ -16,12 +16,11 @@ class PrometheusProvider {
 fun MeterRegistry.fordelingsCounter(system: Fagsystem): Counter =
     this.counter("fordeling_videresend", listOf(Tag.of("system", system.name)))
 
-fun MeterRegistry.hendelseType(record: JournalfoeringHendelseRecord): Counter =
+fun MeterRegistry.hendelseType(record: JournalfoeringHendelseRecord, type: String): Counter =
     this.counter(
         "joark_hendelse", listOf(
             Tag.of("hendelseType", record.hendelsesType),
-            Tag.of("status", record.journalpostStatus),
-            Tag.of("temaNytt", record.temaNytt),
+            Tag.of("type", type),
         )
     )
 

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/PrometheusProvider.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/PrometheusProvider.kt
@@ -16,11 +16,11 @@ class PrometheusProvider {
 fun MeterRegistry.fordelingsCounter(system: Fagsystem): Counter =
     this.counter("fordeling_videresend", listOf(Tag.of("system", system.name)))
 
-fun MeterRegistry.hendelseType(record: JournalfoeringHendelseRecord, temaNytt: String): Counter =
+fun MeterRegistry.hendelseType(record: JournalfoeringHendelseRecord): Counter =
     this.counter(
         "joark_hendelse", listOf(
             Tag.of("hendelseType", record.hendelsesType),
-            Tag.of("temaNytt", temaNytt),
+            Tag.of("temaNytt", record.temaNytt),
         )
     )
 

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/PrometheusProvider.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/PrometheusProvider.kt
@@ -20,7 +20,6 @@ fun MeterRegistry.hendelseType(record: JournalfoeringHendelseRecord): Counter =
     this.counter(
         "joark_hendelse", listOf(
             Tag.of("hendelseType", record.hendelsesType),
-            Tag.of("temaNytt", record.temaNytt),
         )
     )
 

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/PrometheusProvider.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/PrometheusProvider.kt
@@ -16,11 +16,11 @@ class PrometheusProvider {
 fun MeterRegistry.fordelingsCounter(system: Fagsystem): Counter =
     this.counter("fordeling_videresend", listOf(Tag.of("system", system.name)))
 
-fun MeterRegistry.hendelseType(record: JournalfoeringHendelseRecord, type: String): Counter =
+fun MeterRegistry.hendelseType(record: JournalfoeringHendelseRecord, temaNytt: String): Counter =
     this.counter(
         "joark_hendelse", listOf(
             Tag.of("hendelseType", record.hendelsesType),
-            Tag.of("type", type),
+            Tag.of("temaNytt", temaNytt),
         )
     )
 

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/mottak/KafkaStreams.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/mottak/KafkaStreams.kt
@@ -98,13 +98,13 @@ class JoarkKafkaHandler(
     }
 
     private fun temaendringTopology(stream: KStream<String, JournalfoeringHendelseRecord>) {
-        stream.peek { _, record -> prometheus.hendelseType(record, temaNytt = "ikke_aap") }
+        stream.peek { _, record -> prometheus.hendelseType(record) }
             .mapValues { record -> JournalpostId(record.journalpostId) }
             .foreach { _, record -> håndterTemaendring(record) }
     }
 
     private fun nyJournalpost(stream: KStream<String, JournalfoeringHendelseRecord>) {
-        stream.peek { _, record -> prometheus.hendelseType(record, temaNytt = "AAP") }
+        stream.peek { _, record -> prometheus.hendelseType(record) }
             .foreach { _, record ->
             val journalpostId = record.journalpostId.let(::JournalpostId)
             val åpenBehandling = transactionProvider.inTransaction(readOnly = true) {

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/mottak/KafkaStreams.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/mottak/KafkaStreams.kt
@@ -98,13 +98,13 @@ class JoarkKafkaHandler(
     }
 
     private fun temaendringTopology(stream: KStream<String, JournalfoeringHendelseRecord>) {
-        stream.peek { _, record -> prometheus.hendelseType(record, "temaendring") }
+        stream.peek { _, record -> prometheus.hendelseType(record, temaNytt = "ikke_aap") }
             .mapValues { record -> JournalpostId(record.journalpostId) }
             .foreach { _, record -> håndterTemaendring(record) }
     }
 
     private fun nyJournalpost(stream: KStream<String, JournalfoeringHendelseRecord>) {
-        stream.peek { _, record -> prometheus.hendelseType(record, "ny_journalpost") }
+        stream.peek { _, record -> prometheus.hendelseType(record, temaNytt = "AAP") }
             .foreach { _, record ->
             val journalpostId = record.journalpostId.let(::JournalpostId)
             val åpenBehandling = transactionProvider.inTransaction(readOnly = true) {

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/mottak/KafkaStreams.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/mottak/KafkaStreams.kt
@@ -88,7 +88,6 @@ class JoarkKafkaHandler(
         streamBuilder.stream(JOARK_TOPIC, Consumed.with(Serdes.String(), journalfoeringHendelseAvro.avroserdes))
             .filter(harStatusMottatt)
             .filter(erIkkeKanalEESSI)
-            .peek { _, record -> prometheus.hendelseType(record) }
             .split()
             .branch(erTemaEndretFraAAP, Branched.withConsumer(::temaendringTopology))
             .branch(erTemaAAP, Branched.withConsumer(::nyJournalpost))
@@ -99,12 +98,14 @@ class JoarkKafkaHandler(
     }
 
     private fun temaendringTopology(stream: KStream<String, JournalfoeringHendelseRecord>) {
-        stream.mapValues { record -> JournalpostId(record.journalpostId) }
+        stream.peek { _, record -> prometheus.hendelseType(record, "temaendring") }
+            .mapValues { record -> JournalpostId(record.journalpostId) }
             .foreach { _, record -> håndterTemaendring(record) }
     }
 
     private fun nyJournalpost(stream: KStream<String, JournalfoeringHendelseRecord>) {
-        stream.foreach { _, record ->
+        stream.peek { _, record -> prometheus.hendelseType(record, "ny_journalpost") }
+            .foreach { _, record ->
             val journalpostId = record.journalpostId.let(::JournalpostId)
             val åpenBehandling = transactionProvider.inTransaction(readOnly = true) {
                 behandlingRepository.hentÅpenJournalføringsbehandling(journalpostId)


### PR DESCRIPTION
Kall prometheus.hendelseType inne i branchene i kafka streams i stedet for å kalle den før branchene