### PR TITLE
Støtte opprettelse av sak på journalpost hvis gammel er trukket

### DIFF
--- a/api/src/main/kotlin/no/nav/aap/postmottak/api/faktagrunnlag/sak/AvklarSakDto.kt
+++ b/api/src/main/kotlin/no/nav/aap/postmottak/api/faktagrunnlag/sak/AvklarSakDto.kt
@@ -1,14 +1,15 @@
 package no.nav.aap.postmottak.api.faktagrunnlag.sak
 
+import no.nav.aap.behandlingsflyt.kontrakt.statistikk.ResultatKode
 import no.nav.aap.komponenter.type.Periode
 import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.sak.Saksvurdering
 import no.nav.aap.postmottak.journalpostogbehandling.journalpost.AvsenderMottaker
 import no.nav.aap.postmottak.journalpostogbehandling.journalpost.Dokument
-import no.nav.aap.postmottak.journalpostogbehandling.journalpost.Person
 
 data class SaksInfoDto(
     val saksnummer: String,
-    val periode: Periode
+    val periode: Periode,
+    val resultat: ResultatKode?,
 )
 
 data class AvklarSakVurderingDto(
@@ -25,6 +26,7 @@ data class AvklarSakVurderingDto(
 data class AvklarSakGrunnlagDto(
     val vurdering: AvklarSakVurderingDto?,
     val saksinfo: List<SaksInfoDto>,
+    val kanOppretteNySak: Boolean,
     val brevkode: String,
     val journalposttittel: String? = null,
     val dokumenter: List<Dokument>,

--- a/api/src/main/kotlin/no/nav/aap/postmottak/api/faktagrunnlag/sak/FinnSakApi.kt
+++ b/api/src/main/kotlin/no/nav/aap/postmottak/api/faktagrunnlag/sak/FinnSakApi.kt
@@ -3,6 +3,7 @@ package no.nav.aap.postmottak.api.faktagrunnlag.sak
 import com.papsign.ktor.openapigen.route.path.normal.NormalOpenAPIRoute
 import com.papsign.ktor.openapigen.route.response.respond
 import com.papsign.ktor.openapigen.route.route
+import no.nav.aap.behandlingsflyt.kontrakt.statistikk.ResultatKode
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.repository.RepositoryRegistry
 import no.nav.aap.postmottak.api.journalpostIdFraBehandlingResolver
@@ -43,9 +44,19 @@ fun NormalOpenAPIRoute.finnSakApi(dataSource: DataSource, repositoryRegistry: Re
                         repositoryProvider.provide(JournalpostRepository::class).hentHvisEksisterer(req)
                     ) { "Journalpost ikke funnet. Behandling: ${req.referanse}" }
 
+                val kanOppretteNySak =
+                    relaterteSaker.isEmpty() || relaterteSaker.all { it.resultat == ResultatKode.TRUKKET }
+
                 AvklarSakGrunnlagDto(
                     vurdering = saksvurdering?.let { AvklarSakVurderingDto.toDto(saksvurdering) },
-                    saksinfo = relaterteSaker.map { SaksInfoDto(it.saksnummer, it.periode) },
+                    saksinfo = relaterteSaker.map {
+                        SaksInfoDto(
+                            saksnummer = it.saksnummer,
+                            periode = it.periode,
+                            resultat = it.resultat
+                        )
+                    },
+                    kanOppretteNySak = kanOppretteNySak,
                     brevkode = journalpost.hoveddokumentbrevkode,
                     journalposttittel = journalpost.tittel,
                     dokumenter = journalpost.dokumenter,

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/gateway/BehandlingsflytGateway.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/gateway/BehandlingsflytGateway.kt
@@ -17,7 +17,7 @@ import no.nav.aap.postmottak.journalpostogbehandling.behandling.dokumenter.Kanal
 import no.nav.aap.postmottak.kontrakt.journalpost.JournalpostId
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.*
+import java.util.UUID
 import kotlin.text.Charsets.UTF_8
 
 interface BehandlingsflytGateway : Gateway {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 ktor = "3.4.3"
 komponenter = "2.0.56"
-tilgang = "1.0.221"
+tilgang = "1.0.224"
 arenaoppslag = "0.5.13"
 behandlingsflyt = "0.0.601"
 junit = "6.0.3"

--- a/lib-test/src/main/kotlin/no/nav/aap/postmottak/test/fakes/BehandlingsflytFake.kt
+++ b/lib-test/src/main/kotlin/no/nav/aap/postmottak/test/fakes/BehandlingsflytFake.kt
@@ -1,13 +1,16 @@
 package no.nav.aap.postmottak.test.fakes
 
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import io.ktor.http.*
-import io.ktor.serialization.jackson.*
-import io.ktor.server.application.*
-import io.ktor.server.plugins.contentnegotiation.*
-import io.ktor.server.request.*
-import io.ktor.server.response.*
-import io.ktor.server.routing.*
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.jackson.jackson
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.request.receiveText
+import io.ktor.server.response.respond
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import no.nav.aap.behandlingsflyt.kontrakt.sak.Saksnummer
 import no.nav.aap.behandlingsflyt.kontrakt.statistikk.ResultatKode
 import no.nav.aap.komponenter.json.DefaultJsonMapper
 import no.nav.aap.komponenter.type.Periode
@@ -15,10 +18,10 @@ import no.nav.aap.postmottak.gateway.BehandlingsflytSak
 import no.nav.aap.postmottak.gateway.Klagebehandling
 import no.nav.aap.postmottak.klient.behandlingsflyt.FinnSaker
 import java.time.LocalDate
-import java.util.*
+import java.util.UUID
+import kotlin.random.Random
 
-fun Application.behandlingsflytFake(
-) {
+fun Application.behandlingsflytFake() {
     install(ContentNegotiation) {
         jackson {
             registerModule(JavaTimeModule())
@@ -29,9 +32,10 @@ fun Application.behandlingsflytFake(
         post("/api/sak/finnEllerOpprett") {
             call.respond(
                 BehandlingsflytSak(
-                    "123321123",
-                    Periode(LocalDate.of(2021, 1, 1), LocalDate.of(2024, 1, 31)), null
-                )
+                    saksnummer = Saksnummer.valueOf(Random.nextLong(123456)).toString(),
+                    periode = Periode(LocalDate.of(2021, 1, 1), LocalDate.of(2024, 1, 31)),
+                    resultat = null
+                ),
             )
         }
 
@@ -46,8 +50,9 @@ fun Application.behandlingsflytFake(
                     call.respond(
                         listOf(
                             BehandlingsflytSak(
-                                "123321123",
-                                Periode(LocalDate.of(2021, 1, 1), LocalDate.of(2024, 1, 31)), ResultatKode.TRUKKET
+                                saksnummer = Saksnummer.valueOf(Random.nextLong(123456)).toString(),
+                                periode = Periode(LocalDate.of(2021, 1, 1), LocalDate.of(2024, 1, 31)),
+                                resultat = ResultatKode.TRUKKET
                             )
                         )
                     )
@@ -57,8 +62,9 @@ fun Application.behandlingsflytFake(
                     call.respond(
                         listOf(
                             BehandlingsflytSak(
-                                "123321123",
-                                Periode(LocalDate.of(2021, 1, 1), LocalDate.of(2024, 1, 31)), null
+                                saksnummer = Saksnummer.valueOf(Random.nextLong(123456)).toString(),
+                                periode = Periode(LocalDate.of(2021, 1, 1), LocalDate.of(2024, 1, 31)),
+                                resultat = null
                             )
                         )
                     )

--- a/lib-test/src/main/kotlin/no/nav/aap/postmottak/test/fakes/FakeKonstanter.kt
+++ b/lib-test/src/main/kotlin/no/nav/aap/postmottak/test/fakes/FakeKonstanter.kt
@@ -20,6 +20,7 @@ object TestJournalposter {
     val LEGEERKLÆRING_TRUKKET_SAK = JournalpostId(130)
     val UTENLANDSK_ORGNR = JournalpostId(131)
     val KLAGE_ETTERSENDING = JournalpostId(132)
+    val NY_SØKNAD_MED_TRUKKET_SAK = JournalpostId(133)
 }
 
 

--- a/lib-test/src/main/kotlin/no/nav/aap/postmottak/test/fakes/Saf.kt
+++ b/lib-test/src/main/kotlin/no/nav/aap/postmottak/test/fakes/Saf.kt
@@ -2,13 +2,21 @@ package no.nav.aap.postmottak.test.fakes
 
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import io.ktor.http.*
-import io.ktor.serialization.jackson.*
-import io.ktor.server.application.*
-import io.ktor.server.plugins.contentnegotiation.*
-import io.ktor.server.request.*
-import io.ktor.server.response.*
-import io.ktor.server.routing.*
+import io.ktor.http.ContentDisposition
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.serialization.jackson.jackson
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.application.log
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.request.receive
+import io.ktor.server.response.header
+import io.ktor.server.response.respondOutputStream
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
 import no.nav.aap.behandlingsflyt.kontrakt.hendelse.dokumenter.StudentStatus
 import no.nav.aap.behandlingsflyt.kontrakt.hendelse.dokumenter.SøknadStudentDto
 import no.nav.aap.behandlingsflyt.kontrakt.hendelse.dokumenter.SøknadV0
@@ -114,6 +122,7 @@ private fun getAvsenderMottaker(journalpostId: Long) =
     when (journalpostId) {
         TestJournalposter.UTEN_AVSENDER_MOTTAKER.referanse -> ""
         TestJournalposter.UTENLANDSK_ORGNR.referanse -> ""
+        TestJournalposter.NY_SØKNAD_MED_TRUKKET_SAK.referanse,
         TestJournalposter.LEGEERKLÆRING_TRUKKET_SAK.referanse -> """"avsenderMottaker": {
             "id": "21345345210",
             "type": "FNR",
@@ -261,7 +270,9 @@ private fun finnBruker(journalpostId: Long) =
         TestJournalposter.LEGEERKLÆRING_IKKE_TIL_KELVIN.referanse -> TestIdenter.IDENT_UTEN_SAK_I_KELVIN.identifikator
 
         TestJournalposter.PERSON_MED_SAK_I_ARENA.referanse -> TestIdenter.IDENT_MED_SAK_I_ARENA.identifikator
+        TestJournalposter.NY_SØKNAD_MED_TRUKKET_SAK.referanse,
         TestJournalposter.LEGEERKLÆRING_TRUKKET_SAK.referanse -> TestIdenter.IDENT_MED_TRUKKET_SAK_I_KELVIN.identifikator
+
         TestJournalposter.UTENLANDSK_ORGNR.referanse -> "999999999"
         TestJournalposter.KLAGE_ETTERSENDING.referanse -> TestIdenter.DEFAULT_IDENT_2.identifikator
         else -> TestIdenter.DEFAULT_IDENT.identifikator


### PR DESCRIPTION
Utleder i backend om saksbehandler kan opprette ny sak. 
Sender også resultatet på gamle saker til frontend for å kunne vise tilstanden deres (eks. trukket). 