### PR TITLE
fix: tillat AA115 vedtak i dry sjekk for manuell fordeling

### DIFF
--- a/flyt/src/main/kotlin/no/nav/aap/fordeler/arena/ArenaService.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/fordeler/arena/ArenaService.kt
@@ -34,7 +34,8 @@ class ArenaService(gatewayProvider: GatewayProvider) {
 
             val tilManuellFordeling = !signifikanteVedtakUtoverTypeAap && !flereSignifikanteSaker
                     && maksdatoNærmerSeg && !sisteSak.ferdigAvklart && !sisteSak.utredesForUfor
-            val tilstand = tilstandSomString(signifikanteVedtakUtoverTypeAap, flereSignifikanteSaker, maksdatoNærmerSeg, sisteSak)
+            val tilstand =
+                tilstandSomString(signifikanteVedtakUtoverTypeAap, flereSignifikanteSaker, maksdatoNærmerSeg, sisteSak)
 
             logger.info("Journalpost $journalpostId er 'kant-i-kant': $tilManuellFordeling, sak: $sisteSak, tilstand: $tilstand")
 
@@ -50,7 +51,7 @@ class ArenaService(gatewayProvider: GatewayProvider) {
         sisteSak: SakMedSisteVedtakOgMaksdato
     ): String {
         val logmsg: StringBuilder = StringBuilder()
-        logmsg.append("signifikanteVedtakerUtoverTypeAap=$signifikanteVedtakUtoverTypeAap,")
+        logmsg.append("signifikanteVedtakUtoverTypeAap=$signifikanteVedtakUtoverTypeAap,")
         logmsg.append("flereSignifikanteSaker=$flereSignifikanteSaker,")
         logmsg.append("maksdatoNærmerSeg=$maksdatoNærmerSeg,")
         logmsg.append("ferdigAvklart=${sisteSak.ferdigAvklart},")
@@ -60,11 +61,10 @@ class ArenaService(gatewayProvider: GatewayProvider) {
 
 
     internal fun harSignifikanteVedtakUtoverTypeAap(signifikanteVedtak: List<ArenaVedtak>): Boolean {
-        if (signifikanteVedtak.isEmpty()) return false
+        val rettighetskoder = signifikanteVedtak.map { it.rettighetkode }.toMutableSet()
+        rettighetskoder.removeAll(listOf("AAP", "AA115")) // klager, anker og annet gjenstår
 
-        val rettighetskoder = signifikanteVedtak.map { it.rettighetkode }.distinct()
-        // hvis annet enn AAP
-        return !rettighetskoder.contains("AAP") || rettighetskoder.size > 1
+        return rettighetskoder.isNotEmpty()
     }
 
     internal fun harFlereSignifikanteSaker(
@@ -124,13 +124,13 @@ class ArenaService(gatewayProvider: GatewayProvider) {
             sisteSak.ferdigAvklart -> false
             else -> {
                 val flereSignifikanteSaker = harFlereSignifikanteSaker(signifikanteSaker.saker(), sisteSak)
-                val signifikanteVedtakerUtoverTypeAap =
+                val signifikanteVedtakUtoverTypeAap =
                     harSignifikanteVedtakUtoverTypeAap(signifikanteSaker.signifikanteVedtak)
 
                 sisteSak.har_11_12_forlengelse // er tidligere forlenget
                         && sakenHarBegyntPåAndreÅretMedUnntak(mottattDato, sisteSak) // på andre året
                         && maksdatoNærmerSeg(sisteSak, mottattDato) // og utløpet av ytelsen nærmer seg
-                        && !signifikanteVedtakerUtoverTypeAap && !flereSignifikanteSaker
+                        && !signifikanteVedtakUtoverTypeAap && !flereSignifikanteSaker
             }
         }
 

--- a/flyt/src/test/kotlin/no/nav/aap/fordeler/arena/ArenaServiceTest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/fordeler/arena/ArenaServiceTest.kt
@@ -30,27 +30,28 @@ class ArenaServiceTest {
     }
 
     @Test
-    fun `returnerer true naar det er flere rettighetskoder`() {
+    fun `harSignifikanteVedtakUtoverTypeAap returnerer true naar det er klage`() {
         val vedtak = listOf(
             arenaVedtak(rettighetskode = "AAP"),
-            arenaVedtak(rettighetskode = "AA115")
+            arenaVedtak(rettighetskode = "AA115"),
+            arenaVedtak(rettighetskode = "KLAG1")
         )
 
         assertTrue(arenaService.harSignifikanteVedtakUtoverTypeAap(vedtak))
     }
 
     @Test
-    fun `returnerer true naar rettighetskoder ikke inneholder AAP`() {
-        val vedtak = listOf(arenaVedtak(rettighetskode = "KLAGE"))
+    fun `harSignifikanteVedtakUtoverTypeAap returnerer true naar rettighetskoder ikke inneholder AAP`() {
+        val vedtak = listOf(arenaVedtak(rettighetskode = "KLAG1"))
 
         assertTrue(arenaService.harSignifikanteVedtakUtoverTypeAap(vedtak))
     }
 
     @Test
-    fun `returnerer true naar det finnes flere rettighetskoder inkludert AAP`() {
+    fun `harSignifikanteVedtakUtoverTypeAap returnerer true naar det finnes flere rettighetskoder inkludert AAP`() {
         val vedtak = listOf(
             arenaVedtak(rettighetskode = "AAP"),
-            arenaVedtak(rettighetskode = "KLAGE")
+            arenaVedtak(rettighetskode = "KLAG1")
         )
 
         assertTrue(arenaService.harSignifikanteVedtakUtoverTypeAap(vedtak))


### PR DESCRIPTION
Eksistensen av et AA115 vedtak er ikke grunn i seg selv til å ikke gjennomføre manuell vurdering.

Endrer ikke Fordelingen, kun målinger. 

AAPM-121