### PR TITLE
AAP-2194 Hente saksnummer fra avklaring (driftApi)

### DIFF
--- a/api/src/main/kotlin/no/nav/aap/postmottak/api/drift/DriftApi.kt
+++ b/api/src/main/kotlin/no/nav/aap/postmottak/api/drift/DriftApi.kt
@@ -14,6 +14,7 @@ import no.nav.aap.motor.JobbInput
 import no.nav.aap.postmottak.api.journalpostIdFraBehandlingResolver
 import no.nav.aap.postmottak.avklaringsbehov.AvklaringsbehovRepository
 import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.JournalpostRepository
+import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.sak.SaksnummerRepository
 import no.nav.aap.postmottak.journalpostogbehandling.behandling.BehandlingRepository
 import no.nav.aap.postmottak.journalpostogbehandling.behandling.Behandlingsreferanse
 import no.nav.aap.postmottak.journalpostogbehandling.behandling.BehandlingsreferansePathParam
@@ -79,6 +80,7 @@ fun NormalOpenAPIRoute.driftApi(
                     val journalpostRepository = repositoryProvider.provide<JournalpostRepository>()
                     val behandlingRepository = repositoryProvider.provide<BehandlingRepository>()
                     val avklaringsbehovRepository = repositoryProvider.provide<AvklaringsbehovRepository>()
+                    val saksnummerRepository = repositoryProvider.provide<SaksnummerRepository>()
 
                     val innkommendeJournalpost = innkommendeJournalpostRepository.hentHvisEksisterer(journalpostId)
                     val journalpost = journalpostRepository.hentHvisEksisterer(journalpostId)
@@ -116,7 +118,8 @@ fun NormalOpenAPIRoute.driftApi(
                         journalstatus = journalpost?.status,
                         mottattDato = journalpost?.mottattDato,
                         kanal = journalpost?.kanal,
-                        saksnummer = journalpost?.saksnummer,
+                        saksnummer = journalpost?.saksnummer
+                            ?: saksnummerRepository.hentSaksnummerForJournalpost(journalpostId),
                         behandlinger = behandlinger,
                     )
                 }

--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/faktagrunnlag/saksbehandler/dokument/sak/SaksnummerRepository.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/faktagrunnlag/saksbehandler/dokument/sak/SaksnummerRepository.kt
@@ -2,6 +2,7 @@ package no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.sak
 
 import no.nav.aap.lookup.repository.Repository
 import no.nav.aap.postmottak.journalpostogbehandling.behandling.BehandlingId
+import no.nav.aap.postmottak.kontrakt.journalpost.JournalpostId
 
 interface SaksnummerRepository: Repository {
     fun hentKelvinSaker(behandlingId: BehandlingId): List<Saksinfo>
@@ -11,5 +12,6 @@ interface SaksnummerRepository: Repository {
     )
     fun lagreSakVurdering(behandlingId: BehandlingId, saksvurdering: Saksvurdering)
     fun hentSakVurdering(behandlingId: BehandlingId): Saksvurdering?
+    fun hentSaksnummerForJournalpost(journalpostId: JournalpostId): String?
     fun eksistererAvslagPåTidligereBehandling(behandlingId: BehandlingId): Boolean
 }

--- a/repository/src/main/kotlin/no/nav/aap/postmottak/repository/faktagrunnlag/SaksnummerRepositoryImpl.kt
+++ b/repository/src/main/kotlin/no/nav/aap/postmottak/repository/faktagrunnlag/SaksnummerRepositoryImpl.kt
@@ -10,6 +10,7 @@ import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.sak.Saksnummer
 import no.nav.aap.postmottak.faktagrunnlag.saksbehandler.dokument.sak.Saksvurdering
 import no.nav.aap.postmottak.gateway.AvsenderMottakerDto
 import no.nav.aap.postmottak.journalpostogbehandling.behandling.BehandlingId
+import no.nav.aap.postmottak.kontrakt.journalpost.JournalpostId
 
 class SaksnummerRepositoryImpl(private val connection: DBConnection) : SaksnummerRepository {
 
@@ -140,6 +141,22 @@ class SaksnummerRepositoryImpl(private val connection: DBConnection) : Saksnumme
             }
         }
     }
+
+    override fun hentSaksnummerForJournalpost(journalpostId: JournalpostId): String? =
+        connection.queryFirstOrNull(
+            """
+            SELECT sa.SAKSNUMMER
+            FROM SAKSVURDERING_GRUNNLAG sg
+            JOIN SAKSNUMMER_AVKLARING sa ON sa.ID = sg.SAKSNUMMER_AVKLARING_ID
+            JOIN BEHANDLING b ON b.ID = sg.BEHANDLING_ID
+            WHERE b.JOURNALPOST_ID = ? AND sg.AKTIV
+            ORDER BY sg.OPPRETTET_TID DESC
+            LIMIT 1
+            """.trimIndent()
+        ) {
+            setParams { setLong(1, journalpostId.referanse) }
+            setRowMapper { row -> row.getStringOrNull("SAKSNUMMER") }
+        }
 
     override fun eksistererAvslagPåTidligereBehandling(behandlingId: BehandlingId): Boolean {
         val kelvinSaker = hentKelvinSaker(behandlingId)


### PR DESCRIPTION
Hente saksnummer fra avklaring siden saksnummer kun finnes på journalposter som allerede har det når de kommer inn i Kelvin. 