### PR TITLE
AAP-2219 Ikke overføre meldekort uten dokument til fagsystem

### DIFF
--- a/flyt/src/main/kotlin/no/nav/aap/postmottak/forretningsflyt/steg/dokumentflyt/OverleverTilFagsystemSteg.kt
+++ b/flyt/src/main/kotlin/no/nav/aap/postmottak/forretningsflyt/steg/dokumentflyt/OverleverTilFagsystemSteg.kt
@@ -63,8 +63,14 @@ class OverleverTilFagsystemSteg(
                 InnsendingType.KLAGE
             )
         ) {
-            val vurdering = OverleveringVurdering(true)
-            overleveringVurderingRepository.lagre(kontekst.behandlingId, OverleveringVurdering(true))
+            val skalOverleveresTilKelvin = when {
+                // Meldekort uten strukturert dokument skal ikke oversendes fagsystem da dette allerede er registrert manuelt i Kelvin
+                digitaliseringsvurdering.kategori == InnsendingType.MELDEKORT && digitaliseringsvurdering.strukturertDokument == null -> false
+                else -> true
+            }
+
+            val vurdering = OverleveringVurdering(skalOverleveresTilKelvin)
+            overleveringVurderingRepository.lagre(kontekst.behandlingId, vurdering)
             overleveringVurdering = vurdering
         }
 

--- a/flyt/src/test/kotlin/no/nav/aap/postmottak/forretningsflyt/steg/dokumentflyt/OverleverTilFagsystemStegTest.kt
+++ b/flyt/src/test/kotlin/no/nav/aap/postmottak/forretningsflyt/steg/dokumentflyt/OverleverTilFagsystemStegTest.kt
@@ -181,6 +181,27 @@ class OverleverTilFagsystemStegTest {
                 false
             )
         }
-        assertThat(stegresultat::class.simpleName).isEqualTo(Fullført::class.simpleName)
+        assertThat(stegresultat).isEqualTo(Fullført)
+    }
+
+    @Test
+    fun `hvis meldekort ikke inneholder strukturert dokument blir det ikke overført til fagsystem`() {
+        val kontekst: FlytKontekst = mockk(relaxed = true)
+        val digitaliseringsvurdering = Digitaliseringsvurdering(
+            InnsendingType.MELDEKORT, null, mottattDato, true
+        )
+        every { struktureringsvurderingRepository.hentHvisEksisterer(any()) } returns digitaliseringsvurdering
+        every { overleveringVurderingRepository.hentHvisEksisterer(any()) } returns null
+        every { overleveringVurderingRepository.lagre(any(), any()) } returns Unit
+
+        val stegresultat = overførTilFagsystemSteg.utfør(kontekst)
+
+        verify(exactly = 1) {
+            overleveringVurderingRepository.lagre(any(), OverleveringVurdering(false))
+        }
+        verify(exactly = 0) {
+            behandlingsflytKlient.sendHendelse(any(), any(), any(), any(), any(), any(), any())
+        }
+        assertThat(stegresultat).isEqualTo(Fullført)
     }
 }


### PR DESCRIPTION
I tilfeller hvor saksbehandler allerede har registrert meldekort i Kelvin, skal saksbehandler kunne huke av for at meldekort allerede er registrert og dermed kunne fullføre digitaliseringen uten at det overføres til Kelvin for videre prosessering. 

Måten dette gjøres på er å løse behovet for MELDEKORT, men uten noe strukturert dokument da saksbehandler ikke oppgir dette. 